### PR TITLE
Refactor configuration

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
@@ -70,7 +70,7 @@ public class JdbcSourceConnector extends SourceConnector {
                                  e);
     }
 
-    final String dbUrl = config.getString(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
+    final String dbUrl = config.getConnectionUrl();
     final int maxConnectionAttempts = config.getInt(
         JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG
     );

--- a/src/main/java/io/aiven/connect/jdbc/config/DatabaseDialectRecommender.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/DatabaseDialectRecommender.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  **/
 
-package io.aiven.connect.jdbc.util;
+package io.aiven.connect.jdbc.config;
 
 import io.aiven.connect.jdbc.dialect.DatabaseDialects;
 import org.apache.kafka.common.config.ConfigDef;

--- a/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
@@ -16,14 +16,142 @@
 
 package io.aiven.connect.jdbc.config;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.types.Password;
 
-public class JdbcConfig {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class JdbcConfig extends AbstractConfig {
+  private static final String DATABASE_GROUP = "Database";
+
+  public static final String CONNECTION_URL_CONFIG = "connection.url";
+  private static final String CONNECTION_URL_DOC = "JDBC connection URL.";
+  private static final String CONNECTION_URL_DISPLAY = "JDBC URL";
+
+  public static final String CONNECTION_USER_CONFIG = "connection.user";
+  private static final String CONNECTION_USER_DOC = "JDBC connection user.";
+  private static final String CONNECTION_USER_DISPLAY = "JDBC User";
+
+  public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+  private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
+  private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
+
+  public static final String DIALECT_NAME_CONFIG = "dialect.name";
+  private static final String DIALECT_NAME_DISPLAY = "Database Dialect";
+  private static final String DIALECT_NAME_DEFAULT = "";
+  private static final String DIALECT_NAME_DOC =
+      "The name of the database dialect that should be used for this connector. By default this "
+          + "is empty, and the connector automatically determines the dialect based upon the "
+          + "JDBC connection URL. Use this if you want to override that behavior and use a "
+          + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
+          + "can be used.";
+
   public static final String SQL_QUOTE_IDENTIFIERS_CONFIG = "sql.quote.identifiers";
-  public static final ConfigDef.Type SQL_QUOTE_IDENTIFIERS_TYPE = ConfigDef.Type.BOOLEAN;
-  public static final Boolean SQL_QUOTE_IDENTIFIERS_DEFAULT = true;
-  public static final String SQL_QUOTE_IDENTIFIERS_DOC =
+  private static final Boolean SQL_QUOTE_IDENTIFIERS_DEFAULT = true;
+  private static final String SQL_QUOTE_IDENTIFIERS_DOC =
       "Whether to delimit (in most databases, quote with double quotes) identifiers "
           + "(e.g., table names and column names) in SQL statements.";
-  public static final String SQL_QUOTE_IDENTIFIERS_DISPLAY = "Quote Identifiers";
+  private static final String SQL_QUOTE_IDENTIFIERS_DISPLAY = "Quote SQL Identifiers";
+
+  public JdbcConfig(final ConfigDef definition, final Map<?, ?> originals) {
+    super(definition, originals);
+  }
+
+  public final String getDialectName() {
+    return getString(DIALECT_NAME_CONFIG);
+  }
+
+  public final String getConnectionUrl() {
+    return getString(CONNECTION_URL_CONFIG);
+  }
+
+  public final String getConnectionUser() {
+    return getString(CONNECTION_USER_CONFIG);
+  }
+
+  public final Password getConnectionPassword() {
+    return getPassword(CONNECTION_PASSWORD_CONFIG);
+  }
+
+  public final boolean isQuoteSqlIdentifiers() {
+    return getBoolean(SQL_QUOTE_IDENTIFIERS_CONFIG);
+  }
+
+  protected static void defineConnectionUrl(final ConfigDef configDef,
+                                            final int orderInGroup,
+                                            final Collection<String> extraDependents) {
+    configDef.define(
+        CONNECTION_URL_CONFIG,
+        ConfigDef.Type.STRING,
+        ConfigDef.NO_DEFAULT_VALUE,
+        ConfigDef.Importance.HIGH,
+        CONNECTION_URL_DOC,
+        DATABASE_GROUP,
+        orderInGroup,
+        ConfigDef.Width.LONG,
+        CONNECTION_URL_DISPLAY,
+        new ArrayList<>(extraDependents)
+    );
+  }
+
+  protected static void defineConnectionUser(final ConfigDef configDef, final int orderInGroup) {
+    configDef.define(
+        CONNECTION_USER_CONFIG,
+        ConfigDef.Type.STRING,
+        null,
+        ConfigDef.Importance.HIGH,
+        CONNECTION_USER_DOC,
+        DATABASE_GROUP,
+        orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        CONNECTION_USER_DISPLAY
+    );
+  }
+
+  protected static void defineConnectionPassword(final ConfigDef configDef, final int orderInGroup) {
+    configDef.define(
+        CONNECTION_PASSWORD_CONFIG,
+        ConfigDef.Type.PASSWORD,
+        null,
+        ConfigDef.Importance.HIGH,
+        CONNECTION_PASSWORD_DOC,
+        DATABASE_GROUP,
+        orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        CONNECTION_PASSWORD_DISPLAY
+    );
+  }
+
+  protected static void defineDialectName(final ConfigDef configDef, final int orderInGroup) {
+    configDef.define(
+        DIALECT_NAME_CONFIG,
+        ConfigDef.Type.STRING,
+        DIALECT_NAME_DEFAULT,
+        DatabaseDialectRecommender.INSTANCE,
+        ConfigDef.Importance.LOW,
+        DIALECT_NAME_DOC,
+        DATABASE_GROUP,
+        orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        DIALECT_NAME_DISPLAY,
+        DatabaseDialectRecommender.INSTANCE
+    );
+  }
+
+  protected static void defineSqlQuoteIdentifiers(final ConfigDef configDef, final int orderInGroup) {
+    configDef.define(
+        JdbcConfig.SQL_QUOTE_IDENTIFIERS_CONFIG,
+        ConfigDef.Type.BOOLEAN,
+        JdbcConfig.SQL_QUOTE_IDENTIFIERS_DEFAULT,
+        ConfigDef.Importance.LOW,
+        JdbcConfig.SQL_QUOTE_IDENTIFIERS_DOC,
+        DATABASE_GROUP,
+        orderInGroup,
+        ConfigDef.Width.SHORT,
+        JdbcConfig.SQL_QUOTE_IDENTIFIERS_DISPLAY
+    );
+  }
 }

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialectProvider.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialectProvider.java
@@ -17,7 +17,7 @@
 
 package io.aiven.connect.jdbc.dialect;
 
-import org.apache.kafka.common.config.AbstractConfig;
+import io.aiven.connect.jdbc.config.JdbcConfig;
 
 import java.sql.Connection;
 import java.util.*;
@@ -29,7 +29,7 @@ import java.util.*;
  * <p>The {@link DatabaseDialects} class uses Java's Service Provider API to discover and register
  * all {@link DatabaseDialectProvider} classes that are on the classpath. All of these registered
  * providers are then consulted any time someone attempts to
- * {@link DatabaseDialects#findBestFor(String, AbstractConfig) find the best dialect} for a given
+ * {@link DatabaseDialects#findBestFor(String, JdbcConfig) find the best dialect} for a given
  * URL and JDBC source or sink connector configuration. The dialect providers compute a score
  * for the URL, and the dialect provider with the highest score is then used to create a new
  * {@link DatabaseDialect} instance.
@@ -122,7 +122,7 @@ public abstract class DatabaseDialectProvider {
    * @param config the connector configuration
    * @return the dialect instance; never null
    */
-  public abstract DatabaseDialect create(AbstractConfig config);
+  public abstract DatabaseDialect create(JdbcConfig config);
 
   /**
    * Return the name of the dialect.

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialects.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialects.java
@@ -17,8 +17,8 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.JdbcUrlInfo;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +111,7 @@ public class DatabaseDialects {
    */
   public static DatabaseDialect findBestFor(
       String jdbcUrl,
-      AbstractConfig config
+      JdbcConfig config
   ) throws ConnectException {
     final JdbcUrlInfo info = extractJdbcUrlInfo(jdbcUrl);
     LOG.debug("Finding best dialect for {}", info);
@@ -143,7 +143,7 @@ public class DatabaseDialects {
    */
   public static DatabaseDialect create(
       String dialectName,
-      AbstractConfig config
+      JdbcConfig config
   ) throws ConnectException {
     LOG.debug("Looking for named dialect '{}'", dialectName);
     Set<String> dialectNames = new HashSet<>();

--- a/src/main/java/io/aiven/connect/jdbc/dialect/Db2DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/Db2DatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -45,7 +45,7 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new Db2DatabaseDialect(config);
     }
   }
@@ -55,7 +55,7 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public Db2DatabaseDialect(AbstractConfig config) {
+  public Db2DatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DerbyDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DerbyDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -45,7 +45,7 @@ public class DerbyDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new DerbyDatabaseDialect(config);
     }
   }
@@ -55,7 +55,7 @@ public class DerbyDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public DerbyDatabaseDialect(AbstractConfig config) {
+  public DerbyDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -48,7 +48,7 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new MySqlDatabaseDialect(config);
     }
   }
@@ -58,7 +58,7 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public MySqlDatabaseDialect(AbstractConfig config) {
+  public MySqlDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "`", "`"));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -47,7 +47,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new OracleDatabaseDialect(config);
     }
   }
@@ -57,7 +57,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public OracleDatabaseDialect(AbstractConfig config) {
+  public OracleDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -17,11 +17,11 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.source.ColumnMapping;
 import io.aiven.connect.jdbc.util.*;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
@@ -44,7 +44,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new PostgreSqlDatabaseDialect(config);
     }
   }
@@ -57,7 +57,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public PostgreSqlDatabaseDialect(AbstractConfig config) {
+  public PostgreSqlDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/SapHanaDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/SapHanaDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -48,7 +48,7 @@ public class SapHanaDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new SapHanaDatabaseDialect(config);
     }
   }
@@ -58,7 +58,7 @@ public class SapHanaDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public SapHanaDatabaseDialect(AbstractConfig config) {
+  public SapHanaDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -17,10 +17,10 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.*;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -46,7 +46,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new SqlServerDatabaseDialect(config);
     }
   }
@@ -56,7 +56,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public SqlServerDatabaseDialect(AbstractConfig config) {
+  public SqlServerDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "[", "]"));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/SqliteDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/SqliteDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -48,7 +48,7 @@ public class SqliteDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new SqliteDatabaseDialect(config);
     }
   }
@@ -58,7 +58,7 @@ public class SqliteDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public SqliteDatabaseDialect(AbstractConfig config) {
+  public SqliteDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "`", "`"));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -17,13 +17,13 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.ColumnId;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.*;
 
 import java.sql.Connection;
@@ -50,7 +50,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new SybaseDatabaseDialect(config);
     }
   }
@@ -60,7 +60,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public SybaseDatabaseDialect(AbstractConfig config) {
+  public SybaseDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/VerticaDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/VerticaDatabaseDialect.java
@@ -17,11 +17,11 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableId;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
@@ -45,7 +45,7 @@ public class VerticaDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new VerticaDatabaseDialect(config);
     }
   }
@@ -55,7 +55,7 @@ public class VerticaDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public VerticaDatabaseDialect(AbstractConfig config) {
+  public VerticaDatabaseDialect(JdbcConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkTask.java
@@ -49,10 +49,12 @@ public class JdbcSinkTask extends SinkTask {
   }
 
   void initWriter() {
-    if (config.dialectName != null && !config.dialectName.trim().isEmpty()) {
-      dialect = DatabaseDialects.create(config.dialectName, config);
+    final String dialectName = config.getDialectName();
+    if (dialectName != null && !dialectName.trim().isEmpty()) {
+      dialect = DatabaseDialects.create(dialectName, config);
     } else {
-      dialect = DatabaseDialects.findBestFor(config.connectionUrl, config);
+      final String connectionUrl = config.getConnectionUrl();
+      dialect = DatabaseDialects.findBestFor(connectionUrl, config);
     }
     final DbStructure dbStructure = new DbStructure(dialect);
     log.info("Initializing writer using SQL dialect: {}", dialect.getClass().getSimpleName());

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -71,15 +71,15 @@ public class JdbcSourceTask extends SourceTask {
       throw new ConnectException("Couldn't start JdbcSourceTask due to configuration error", e);
     }
 
-    final String url = config.getString(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
     final int maxConnAttempts = config.getInt(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG);
     final long retryBackoff = config.getLong(JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG);
 
-    final String dialectName = config.getString(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG);
+    final String dialectName = config.getDialectName();
     if (dialectName != null && !dialectName.trim().isEmpty()) {
       dialect = DatabaseDialects.create(dialectName, config);
     } else {
-      dialect = DatabaseDialects.findBestFor(url, config);
+      final String connectionUrl = config.getConnectionUrl();
+      dialect = DatabaseDialects.findBestFor(connectionUrl, config);
     }
     log.info("Using JDBC dialect {}", dialect.name());
 

--- a/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
@@ -17,6 +17,7 @@
 
 package io.aiven.connect.jdbc;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.source.EmbeddedDerby;
 import io.aiven.connect.jdbc.util.CachedConnectionProvider;
 import io.aiven.connect.jdbc.util.ExpressionBuilder;
@@ -66,7 +67,7 @@ public class JdbcSourceConnectorTest {
     connector = new JdbcSourceConnector();
     db = new EmbeddedDerby();
     connProps = new HashMap<>();
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
   }
@@ -92,14 +93,14 @@ public class JdbcSourceConnectorTest {
   @Test(expected = ConnectException.class)
   public void testMissingModeConfig() throws Exception {
     HashMap<String, String> connProps = new HashMap<>();
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     connector.start(Collections.<String, String>emptyMap());
   }
 
   @Test(expected = ConnectException.class)
   public void testStartConnectionFailure() throws Exception {
     // Invalid URL
-    connector.start(Collections.singletonMap(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:foo"));
+    connector.start(Collections.singletonMap(JdbcConfig.CONNECTION_URL_CONFIG, "jdbc:foo"));
   }
 
   @Test
@@ -197,7 +198,7 @@ public class JdbcSourceConnectorTest {
   private void assertTaskConfigsHaveParentConfigs(List<Map<String, String>> configs) {
     for (Map<String, String> config : configs) {
       assertEquals(this.db.getUrl(),
-                   config.get(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG));
+                   config.get(JdbcConfig.CONNECTION_URL_CONFIG));
     }
   }
 

--- a/src/test/java/io/aiven/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/BaseDialectTest.java
@@ -176,7 +176,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
     connProps.putAll(propertiesFromPairs(propertyPairs));
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, url);
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, url);
     if (quoteIdentifiers == null) {
       // no-op
     } else {
@@ -198,7 +198,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   ) {
     Map<String, String> connProps = new HashMap<>();
     connProps.putAll(propertiesFromPairs(propertyPairs));
-    connProps.put(JdbcSinkConfig.CONNECTION_URL, url);
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, url);
     return new JdbcSinkConfig(connProps);
   }
 

--- a/src/test/java/io/aiven/connect/jdbc/dialect/BaseDialectTypeTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/BaseDialectTypeTest.java
@@ -15,6 +15,7 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.source.ColumnMapping;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
@@ -162,7 +163,7 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
     connProps.putAll(propertiesFromPairs(propertyPairs));
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, url);
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, url);
     connProps.put(JdbcSourceConnectorConfig.NUMERIC_MAPPING_CONFIG, numMapping.toString());
     return new JdbcSourceConnectorConfig(connProps);
   }

--- a/src/test/java/io/aiven/connect/jdbc/dialect/DatabaseDialectsTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/DatabaseDialectsTest.java
@@ -15,6 +15,7 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
@@ -115,7 +116,7 @@ public class DatabaseDialectsTest {
       String url
   ) {
     Map<String, String> props = new HashMap<>();
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, url);
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, url);
     props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "prefix");
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     JdbcSourceConnectorConfig config = new JdbcSourceConnectorConfig(props);

--- a/src/test/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -15,8 +15,8 @@
 
 package io.aiven.connect.jdbc.dialect;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -72,7 +72,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   public void setup() throws Exception {
     db = new EmbeddedDerby();
     connProps = new HashMap<>();
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
     newDialectFor(null, null);
@@ -94,7 +94,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
     return new GenericDatabaseDialect(sourceConfigWithUrl(db.getUrl()));
   }
 
-  protected GenericDatabaseDialect createDialect(AbstractConfig config) {
+  protected GenericDatabaseDialect createDialect(JdbcConfig config) {
     return new GenericDatabaseDialect(config);
   }
 

--- a/src/test/java/io/aiven/connect/jdbc/dialect/MockDatabaseDialect.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/MockDatabaseDialect.java
@@ -15,7 +15,7 @@
 
 package io.aiven.connect.jdbc.dialect;
 
-import org.apache.kafka.common.config.AbstractConfig;
+import io.aiven.connect.jdbc.config.JdbcConfig;
 
 import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 
@@ -30,7 +30,7 @@ public class MockDatabaseDialect extends GenericDatabaseDialect {
     }
 
     @Override
-    public DatabaseDialect create(AbstractConfig config) {
+    public DatabaseDialect create(JdbcConfig config) {
       return new MockDatabaseDialect(config);
     }
   }
@@ -40,7 +40,7 @@ public class MockDatabaseDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public MockDatabaseDialect(AbstractConfig config) {
+  public MockDatabaseDialect(JdbcConfig config) {
     super(config);
   }
 }

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.DateTimeUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -233,7 +234,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     task.initialize(ctx);
 
     Map<String, String> props = new HashMap<>();
-    props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, "stub");
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
     task.start(props);

--- a/src/test/java/io/aiven/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -21,6 +21,7 @@ import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.TimeZone;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.aiven.connect.jdbc.sink.metadata.SchemaPair;
 import io.aiven.connect.jdbc.util.DateTimeUtils;
@@ -58,9 +59,9 @@ public class PreparedStatementBinderTest {
   @Before
   public void beforeEach() {
     Map<String, String> props = new HashMap<>();
-    props.put(JdbcSinkConfig.CONNECTION_URL, "jdbc:bogus:something");
-    props.put(JdbcSinkConfig.CONNECTION_USER, "sa");
-    props.put(JdbcSinkConfig.CONNECTION_PASSWORD, "password");
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, "jdbc:bogus:something");
+    props.put(JdbcConfig.CONNECTION_USER_CONFIG, "sa");
+    props.put(JdbcConfig.CONNECTION_PASSWORD_CONFIG, "password");
     JdbcSinkConfig config = new JdbcSinkConfig(props);
     dialect = new GenericDatabaseDialect(config);
   }

--- a/src/test/java/io/aiven/connect/jdbc/sink/SqliteHelperTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/SqliteHelperTest.java
@@ -17,6 +17,7 @@
 
 package io.aiven.connect.jdbc.sink;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.ColumnDefinition;
 import io.aiven.connect.jdbc.util.TableDefinition;
 import io.aiven.connect.jdbc.util.TableId;
@@ -75,7 +76,7 @@ public class SqliteHelperTest {
     sqliteHelper.createTable(createNonPkTable);
 
     Map<String, String> connProps = new HashMap<>();
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, sqliteHelper.sqliteUri());
+    connProps.put(JdbcConfig.CONNECTION_URL_CONFIG, sqliteHelper.sqliteUri());
     JdbcSinkConfig config = new JdbcSinkConfig(connProps);
     DatabaseDialect dialect = new SqliteDatabaseDialect(config);
 

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -16,6 +16,7 @@
  **/
 package io.aiven.connect.jdbc.source;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Recommender;
 import org.apache.kafka.common.config.ConfigValue;
@@ -84,7 +85,7 @@ public class JdbcSourceConnectorConfigTest {
 
   @Test
   public void testConfigTableNameRecommenderWithoutSchemaOrTableTypes() throws Exception {
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
     assertWhitelistRecommendations("some_table", "public_table", "private_table", "another_private_table");
@@ -93,7 +94,7 @@ public class JdbcSourceConnectorConfigTest {
 
   @Test
   public void testConfigTableNameRecommenderWitSchemaAndWithoutTableTypes() throws Exception {
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
@@ -103,7 +104,7 @@ public class JdbcSourceConnectorConfigTest {
 
   @Test
   public void testConfigTableNameRecommenderWithSchemaAndTableTypes() throws Exception {
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
     props.put(JdbcSourceConnectorConfig.TABLE_TYPE_CONFIG, "VIEW");
     configDef = JdbcSourceConnectorConfig.baseConfigDef();

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -17,6 +17,7 @@
 
 package io.aiven.connect.jdbc.source;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.CachedConnectionProvider;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -51,7 +52,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   @Test(expected = ConnectException.class)
   public void testMissingParentConfig() {
     Map<String, String> props = singleTableConfig();
-    props.remove(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
+    props.remove(JdbcConfig.CONNECTION_URL_CONFIG);
     task.start(props);
   }
 

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -17,6 +17,7 @@
 
 package io.aiven.connect.jdbc.source;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.TableId;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -93,7 +94,7 @@ public class JdbcSourceTaskTestBase {
 
   protected Map<String, String> singleTableConfig(boolean completeMapping) {
     Map<String, String> props = new HashMap<>();
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     props.put(JdbcSourceTaskConfig.TABLES_CONFIG, SINGLE_TABLE_NAME);
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);
@@ -107,7 +108,7 @@ public class JdbcSourceTaskTestBase {
 
   protected Map<String, String> twoTableConfig() {
     Map<String, String> props = new HashMap<>();
-    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
     props.put(JdbcSourceTaskConfig.TABLES_CONFIG, SINGLE_TABLE_NAME + "," + SECOND_TABLE_NAME);
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);


### PR DESCRIPTION
This commit does changes related to the configuration of Source
and Sink:
 - Extract some common configuration definitions into `JdbcConfig`;
 - In Sink config, moves configurations from `Connection` group
   under `Database` group.
 - Makes `sql.quote.identifiers` of `LOW` importance instead of
   `MEDIUM`.
 - Makes `connection.user` and `connection.password` of `MEDIUM` width.

From the user's point of view, the only change is the grouping of
configurations: it's more consistent between Sink and Source now.