### PR TITLE
Make correct output of valid values for `db.timezone` + refactoring

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
@@ -16,13 +16,17 @@
 
 package io.aiven.connect.jdbc.config;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.types.Password;
+
+import io.aiven.connect.jdbc.util.TimeZoneValidator;
 
 public class JdbcConfig extends AbstractConfig {
     private static final String DATABASE_GROUP = "Database";
@@ -38,6 +42,13 @@ public class JdbcConfig extends AbstractConfig {
     public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
     private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
     private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
+
+    public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+    private static final String DB_TIMEZONE_DEFAULT = "UTC";
+    private static final String DB_TIMEZONE_CONFIG_DOC =
+        "Name of the JDBC timezone that should be used in the connector when "
+            + "querying with time-based criteria. Defaults to UTC.";
+    private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
     public static final String DIALECT_NAME_CONFIG = "dialect.name";
     private static final String DIALECT_NAME_DISPLAY = "Database Dialect";
@@ -70,6 +81,10 @@ public class JdbcConfig extends AbstractConfig {
 
     public final String getConnectionUser() {
         return getString(CONNECTION_USER_CONFIG);
+    }
+
+    public final TimeZone getDBTimeZone() {
+        return TimeZone.getTimeZone(ZoneId.of(getString(DB_TIMEZONE_CONFIG)));
     }
 
     public final Password getConnectionPassword() {
@@ -122,6 +137,21 @@ public class JdbcConfig extends AbstractConfig {
             orderInGroup,
             ConfigDef.Width.MEDIUM,
             CONNECTION_PASSWORD_DISPLAY
+        );
+    }
+
+    protected static void defineDbTimezone(final ConfigDef configDef, final int orderInGroup) {
+        configDef.define(
+            DB_TIMEZONE_CONFIG,
+            ConfigDef.Type.STRING,
+            DB_TIMEZONE_DEFAULT,
+            TimeZoneValidator.INSTANCE,
+            ConfigDef.Importance.MEDIUM,
+            DB_TIMEZONE_CONFIG_DOC,
+            DATABASE_GROUP,
+            orderInGroup,
+            ConfigDef.Width.MEDIUM,
+            DB_TIMEZONE_CONFIG_DISPLAY
         );
     }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -34,7 +34,6 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -174,14 +173,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
             mapNumerics = NumericMapping.NONE;
         }
 
-        if (config instanceof JdbcSourceConnectorConfig) {
-            timeZone = ((JdbcSourceConnectorConfig) config).timeZone();
-        } else if (config instanceof JdbcSinkConfig) {
-            timeZone = ((JdbcSinkConfig) config).timeZone;
-        } else {
-            timeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
-        }
-
+        timeZone = config.getDBTimeZone();
         quoteIdentifiers = config.isQuoteSqlIdentifiers();
     }
 

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.config.types.Password;
 
 import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.StringUtils;
-import io.aiven.connect.jdbc.util.TimeZoneValidator;
 
 public class JdbcSinkConfig extends JdbcConfig {
 
@@ -41,7 +40,6 @@ public class JdbcSinkConfig extends JdbcConfig {
         INSERT,
         UPSERT,
         UPDATE;
-
     }
 
     public enum PrimaryKeyMode {
@@ -160,18 +158,10 @@ public class JdbcSinkConfig extends JdbcConfig {
 
     private static final ConfigDef.Range NON_NEGATIVE_INT_VALIDATOR = ConfigDef.Range.atLeast(0);
 
-    private static final String CONNECTION_GROUP = "Connection";
     private static final String WRITES_GROUP = "Writes";
     private static final String DATAMAPPING_GROUP = "Data Mapping";
     private static final String DDL_GROUP = "DDL Support";
     private static final String RETRIES_GROUP = "Retries";
-
-    public static final String DB_TIMEZONE_CONFIG = "db.timezone";
-    public static final String DB_TIMEZONE_DEFAULT = "UTC";
-    private static final String DB_TIMEZONE_CONFIG_DOC =
-        "Name of the JDBC timezone that should be used in the connector when "
-            + "inserting time-based values. Defaults to UTC.";
-    private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB Time Zone";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef();
 
@@ -181,6 +171,7 @@ public class JdbcSinkConfig extends JdbcConfig {
         defineConnectionUrl(CONFIG_DEF, ++orderInGroup, Collections.emptyList());
         defineConnectionUser(CONFIG_DEF, ++orderInGroup);
         defineConnectionPassword(CONFIG_DEF, ++orderInGroup);
+        defineDbTimezone(CONFIG_DEF, ++orderInGroup);
         defineDialectName(CONFIG_DEF, ++orderInGroup);
         defineSqlQuoteIdentifiers(CONFIG_DEF, ++orderInGroup);
 
@@ -254,18 +245,7 @@ public class JdbcSinkConfig extends JdbcConfig {
                 4,
                 ConfigDef.Width.LONG,
                 FIELDS_WHITELIST_DISPLAY
-            )
-            .define(
-                DB_TIMEZONE_CONFIG,
-                ConfigDef.Type.STRING,
-                DB_TIMEZONE_DEFAULT,
-                TimeZoneValidator.INSTANCE,
-                ConfigDef.Importance.MEDIUM,
-                DB_TIMEZONE_CONFIG_DOC,
-                DATAMAPPING_GROUP,
-                5,
-                ConfigDef.Width.MEDIUM,
-                DB_TIMEZONE_CONFIG_DISPLAY);
+            );
 
         // DDL
         CONFIG_DEF

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.common.config.ConfigException;
@@ -152,7 +151,6 @@ public class JdbcSourceTask extends SourceTask {
             = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
         final boolean validateNonNulls
             = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
-        final TimeZone timeZone = config.timeZone();
 
         for (final String tableOrQuery : tablesOrQuery) {
             final List<Map<String, String>> tablePartitionsToCheck;
@@ -211,7 +209,7 @@ public class JdbcSourceTask extends SourceTask {
                         incrementingColumn,
                         offset,
                         timestampDelayInterval,
-                        timeZone
+                        config.getDBTimeZone()
                     )
                 );
             } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -225,7 +223,7 @@ public class JdbcSourceTask extends SourceTask {
                         null,
                         offset,
                         timestampDelayInterval,
-                        timeZone
+                        config.getDBTimeZone()
                     )
                 );
             } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -239,7 +237,7 @@ public class JdbcSourceTask extends SourceTask {
                         incrementingColumn,
                         offset,
                         timestampDelayInterval,
-                        timeZone
+                        config.getDBTimeZone()
                     )
                 );
             }

--- a/src/main/java/io/aiven/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/TimeZoneValidator.java
@@ -37,4 +37,9 @@ public class TimeZoneValidator implements ConfigDef.Validator {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "valid time zone identifier (e.g., 'Europe/Helsinki', 'UTC+2', 'Z', 'CET')";
+    }
 }

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.DateTimeUtils;
 
 import org.junit.After;
@@ -750,7 +751,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
         taskConfig.put(
             JdbcSourceConnectorConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, delay == null ? "0" : delay.toString());
         if (timeZone != null) {
-            taskConfig.put(JdbcSourceConnectorConfig.DB_TIMEZONE_CONFIG, timeZone);
+            taskConfig.put(JdbcConfig.DB_TIMEZONE_CONFIG, timeZone);
         }
         task.start(taskConfig);
     }


### PR DESCRIPTION
Closes #7.

The commit:
 - makes the valid values documentation provided by
   `TimeZoneValidator` human-readable;
 - moves `db.timezone` configuration definition to `JdbcConfig`;
 - moves `db.timezone` configuration into `Database` group.