### PR TITLE
Remove default value for `mode` configuration

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -112,7 +112,7 @@ public class JdbcSourceTask extends SourceTask {
             ? Collections.singletonList(query)
             : tables;
 
-        final String mode = config.getString(JdbcSourceTaskConfig.MODE_CONFIG);
+        final String mode = config.getMode();
         //used only in table mode
         final Map<String, List<Map<String, String>>> partitionsByTableFqn = new HashMap<>();
         Map<Map<String, String>, Map<String, Object>> offsets = null;

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -87,6 +87,7 @@ public class JdbcSourceConnectorConfigTest {
 
     @Test
     public void testConfigTableNameRecommenderWithoutSchemaOrTableTypes() throws Exception {
+        props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
         props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
         configDef = JdbcSourceConnectorConfig.baseConfigDef();
         results = configDef.validate(props);
@@ -96,6 +97,7 @@ public class JdbcSourceConnectorConfigTest {
 
     @Test
     public void testConfigTableNameRecommenderWitSchemaAndWithoutTableTypes() throws Exception {
+        props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
         props.put(JdbcConfig.CONNECTION_URL_CONFIG, db.getUrl());
         props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
         configDef = JdbcSourceConnectorConfig.baseConfigDef();


### PR DESCRIPTION
Closes #6.

The commit removes the present default value `""` (empty string), which
is not valid value anyway. The absence of the default value will result
in a better support from Connect's side (including configuration
validation and the generated documentation).