### PR TITLE
Add connector documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,3 +125,22 @@ dependencies {
     testImplementation "org.apache.derby:derby:10.11.1.1"
     testRuntime "org.slf4j:slf4j-log4j12:$slf4jVersion"
 }
+
+task connectorConfigDoc {
+    description = "Generates the connector's configuration documentation."
+    group = "documentation"
+    dependsOn "classes"
+
+    doLast {
+        javaexec {
+            main = "io.aiven.connect.jdbc.source.JdbcSourceConnectorConfig"
+            classpath = sourceSets.main.runtimeClasspath + sourceSets.main.compileClasspath
+            standardOutput = new FileOutputStream("$projectDir/docs/source-connector-config-options.rst")
+        }
+        javaexec {
+            main = "io.aiven.connect.jdbc.sink.JdbcSinkConfig"
+            classpath = sourceSets.main.runtimeClasspath + sourceSets.main.compileClasspath
+            standardOutput = new FileOutputStream("$projectDir/docs/sink-connector-config-options.rst")
+        }
+    }
+}

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -1,0 +1,186 @@
+=========================================
+JDBC Sink connector Configuration Options
+=========================================
+
+Database
+^^^^^^^^
+
+``connection.url``
+  JDBC connection URL.
+
+  * Type: string
+  * Importance: high
+
+``connection.user``
+  JDBC connection user.
+
+  * Type: string
+  * Default: null
+  * Importance: high
+
+``connection.password``
+  JDBC connection password.
+
+  * Type: password
+  * Default: null
+  * Importance: high
+
+``db.timezone``
+  Name of the JDBC timezone that should be used in the connector when querying with time-based criteria. Defaults to UTC.
+
+  * Type: string
+  * Default: UTC
+  * Valid Values: valid time zone identifier (e.g., 'Europe/Helsinki', 'UTC+2', 'Z', 'CET')
+  * Importance: medium
+
+``dialect.name``
+  The name of the database dialect that should be used for this connector. By default this is empty, and the connector automatically determines the dialect based upon the JDBC connection URL. Use this if you want to override that behavior and use a specific dialect. All properly-packaged dialects in the JDBC connector plugin can be used.
+
+  * Type: string
+  * Default: ""
+  * Valid Values: [, Db2DatabaseDialect, MySqlDatabaseDialect, SybaseDatabaseDialect, GenericDatabaseDialect, OracleDatabaseDialect, SqlServerDatabaseDialect, PostgreSqlDatabaseDialect, SqliteDatabaseDialect, DerbyDatabaseDialect, SapHanaDatabaseDialect, VerticaDatabaseDialect]
+  * Importance: low
+
+``sql.quote.identifiers``
+  Whether to delimit (in most databases, quote with double quotes) identifiers (e.g., table names and column names) in SQL statements.
+
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
+Writes
+^^^^^^
+
+``insert.mode``
+  The insertion mode to use. Supported modes are:
+
+  ``insert``
+
+      Use standard SQL ``INSERT`` statements.
+
+  ``upsert``
+
+      Use the appropriate upsert semantics for the target database if it is supported by the connector, e.g. ``INSERT OR IGNORE``.
+
+  ``update``
+
+      Use the appropriate update semantics for the target database if it is supported by the connector, e.g. ``UPDATE``.
+
+  * Type: string
+  * Default: insert
+  * Valid Values: [insert, upsert, update]
+  * Importance: high
+
+``batch.size``
+  Specifies how many records to attempt to batch together for insertion into the destination table, when possible.
+
+  * Type: int
+  * Default: 3000
+  * Valid Values: [0,...]
+  * Importance: medium
+
+Data Mapping
+^^^^^^^^^^^^
+
+``table.name.format``
+  A format string for the destination table name, which may contain '${topic}' as a placeholder for the originating topic name.
+
+  For example, ``kafka_${topic}`` for the topic 'orders' will map to the table name 'kafka_orders'.
+
+  * Type: string
+  * Default: ${topic}
+  * Importance: medium
+
+``pk.mode``
+  The primary key mode, also refer to ``pk.fields`` documentation for interplay. Supported modes are:
+
+  ``none``
+
+      No keys utilized.
+
+  ``kafka``
+
+      Kafka coordinates are used as the PK.
+
+  ``record_key``
+
+      Field(s) from the record key are used, which may be a primitive or a struct.
+
+  ``record_value``
+
+      Field(s) from the record value are used, which must be a struct.
+
+  * Type: string
+  * Default: none
+  * Valid Values: [none, kafka, record_key, record_value]
+  * Importance: high
+
+``pk.fields``
+  List of comma-separated primary key field names. The runtime interpretation of this config depends on the ``pk.mode``:
+
+  ``none``
+
+      Ignored as no fields are used as primary key in this mode.
+
+  ``kafka``
+
+      Must be a trio representing the Kafka coordinates, defaults to ``__connect_topic,__connect_partition,__connect_offset`` if empty.
+
+  ``record_key``
+
+      If empty, all fields from the key struct will be used, otherwise used to extract the desired fields - for primitive key only a single field name must be configured.
+
+  ``record_value``
+
+      If empty, all fields from the value struct will be used, otherwise used to extract the desired fields.
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
+``fields.whitelist``
+  List of comma-separated record value field names. If empty, all fields from the record value are utilized, otherwise used to filter to the desired fields.
+
+  Note that ``pk.fields`` is applied independently in the context of which field(s) form the primary key columns in the destination database, while this configuration is applicable for the other columns.
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
+DDL Support
+^^^^^^^^^^^
+
+``auto.create``
+  Whether to automatically create the destination table based on record schema if it is found to be missing by issuing ``CREATE``.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
+``auto.evolve``
+  Whether to automatically add columns in the table schema when found to be missing relative to the record schema by issuing ``ALTER``.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
+Retries
+^^^^^^^
+
+``max.retries``
+  The maximum number of times to retry on errors before failing the task.
+
+  * Type: int
+  * Default: 10
+  * Valid Values: [0,...]
+  * Importance: medium
+
+``retry.backoff.ms``
+  The time in milliseconds to wait following an error before a retry attempt is made.
+
+  * Type: int
+  * Default: 3000
+  * Valid Values: [0,...]
+  * Importance: medium
+
+

--- a/docs/sink-connector.md
+++ b/docs/sink-connector.md
@@ -1,0 +1,279 @@
+# Kafka Connect JDBC Sink Connector
+
+This [Kafka Connect](https://kafka.apache.org/documentation/#connect)
+connector allows you to transfer data from Kafka topics into a
+relational database.
+
+[Full configuration options reference](sink-connector-config-options.rst).
+
+## How It Works
+
+The connector subscribes to specified Kafka topics (`topics` or
+`topics.regex` configuration, see
+[the Kafka Connect documentation](https://kafka.apache.org/documentation/#connect_configuring))
+and puts records coming from them into corresponding tables in the
+database.
+
+If record keys are used, they must be primitives or structs with
+primitive fields.
+
+Record values must be structs with primitive fields.
+
+The connector requires knowledge of key and value schemas, so you should
+use a converter with schema support, e.g., the JSON converter with
+schema enabled.
+
+It's possible to use a whitelist for record value fields by setting
+`fields.whitelist`. If set, only the specified fields from a record's
+value will be used. Note that the primary key fields are processed
+separately (see [below](#primary-keys)).
+
+## Database
+
+### Connection
+
+The connector is instructed how to connect to the database using
+`connection.url`, `connection.user` and `connection.password`
+configurations.
+
+Some database drivers support SSL encryption of the connection, which is
+configured with the connection URL as well.
+
+The format of the connection URL is specific to the database driver.
+Here are some documentations:
+- [for PostgreSQL](https://jdbc.postgresql.org/documentation/head/connect.html);
+- [for MySQL](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html);
+- [for MariaDB](https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings);
+- [for SQLite](http://www.sqlitetutorial.net/sqlite-java/sqlite-jdbc-driver/);
+- [for Derby](https://db.apache.org/derby/docs/10.15/devguide/cdevdvlp17453.html).
+
+For example, for PostgreSQL the connection URL might look like
+```
+jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true
+```
+
+### SQL Dialects
+
+Different databases use different dialects of SQL. The connector
+supports several of them.
+
+By default, the connector will automatically determine the dialect based
+on the connection URL (`connection.url`).
+
+If needed, it's possible to specify the dialect explicitly using
+`dialect.name` configuration. Check
+[the configuration's reference](source-connector-config-options.rst#database)
+for the list of supported dialects.
+
+## Insertion Modes
+
+The connector has three insertion modes.
+
+### Insert Mode
+
+In this mode, the connector executes `INSERT` SQL query on each record
+from Kafka.
+
+This mode is used by default. To enable it explicitly, set
+`insert.mode=insert`.
+
+### Update Mode
+
+In this mode, the connector executes `UPDATE` SQL query on each record
+from Kafka.
+
+To use this mode, set `insert.mode=update`.
+
+### Upsert Mode
+
+In this mode, the connector executes an SQL query commonly known as
+_upsert_ (it has different names in different databases).
+
+To use this mode, set `insert.mode=upsert`.
+
+#### Write Idempotence
+
+_Upsert_ provides the ability to atomically insert a row if there were
+no conflicts on the primary key constraint or, in case of a conflict, to
+update the existing row with the new data. This semantics provides
+_write idempotence_, which may be desirable in many cases, such as:
+- the source topic naturally containing multiple records with the same
+  primary key;
+- failure recovery when re-processing is involved.
+
+#### Database Support
+
+_Upsert_ is not a standard SQL feature and different databases might not
+support it. Here is the list of databases that support _upsert_ in this
+connector and the syntax they use for this:
+
+|  Database  |                 Syntax used                 |
+|:----------:|---------------------------------------------|
+|    DB2     | `MERGE ..`                                  |
+|   Derby    | `MERGE ..`                                  |
+|    MySQL   | `INSERT .. ON DUPLICATE KEY REPLACE ..`     |
+|   Oracle   | `MERGE ..`                                  |
+| PostgreSQL | `INSERT .. ON CONFLICT .. DO UPDATE SET ..` |
+|  SAP HANA  | `UPSERT ..`                                 |
+|   SQLite   | `INSERT OR REPLACE ..`                      |
+| SQL Server | `MERGE ..`                                  |
+|   Sybase   | `MERGE ..`                                  |
+
+The connector does not support other databases for _upsert_ at the
+moment.
+
+## Primary Keys
+
+The connector supports several sources of the primary key values.
+
+### No Primary Key
+
+This is the simplest mode in which no primary key is used.
+
+This mode is used by default. To enable it explicitly, set
+`pk.mode=none`.
+
+### Kafka Coordinates
+
+In this mode, the connector uses Kafka coordinates—the topic, partition,
+and offset—as a composite primary key.
+
+It is possible to specify the names of the corresponding fields in the
+destination table by configuring:
+```
+pk.fields=<topic_column>,<pratition_column>,<offset_column>
+```
+If not specified, `__connect_topic`, `__connect_partition`, and
+`__connect_offset` will be used.
+
+To use this mode, set `pk.mode=kafka`.
+
+### Record Key
+
+In this mode, the connector uses the record's key as the source of
+primary key values. It may be a primitive or a structure.
+
+If the record key is a primitive, only one field must be specified in
+`pk.fields`, which will be used as the column name.
+
+If the record key is a structure, all or some of its fields can be used.
+By default, it is all. You can specify which fields to use by setting
+`pk.fields`. Note that field name and the column name will be the same.
+
+To use this mode, set `pk.mode=record_key`.
+
+### Record Value
+
+A record's value is supposed to be a structure and in this mode, the
+connector uses the record's value's fields as the source of primary key
+values.
+
+By default, all the fields are used. You can specify which fields to use
+by setting `pk.fields`. Note that field name and the column name will be
+the same.
+
+To use this mode, set `pk.mode=record_value`.
+
+## Table Auto-Creation and Auto-Evolution
+
+### Auto-Creation
+
+The connector can automatically create the destination table if it does
+not exist. Tables will be created as records are being consumed from
+Kafka. The connector will use the record schema, the field whitelist (if
+defined), and the primary key definitions to create the list of the
+table columns.
+
+To enable table auto-creation, set `auto.create=true`.
+
+### Auto-Evolution
+
+If the schema of records changes, the connector can perform limited
+auto-evolution of the destination table by `ALTER` SQL queries. The
+following auto-evolution limitations apply:
+- The connector does not delete columns.
+- The connector does not alter column types.
+- The connector does not add primary keys constraints.
+
+To enable table auto-evolution, set `auto.evolve=true`.
+
+### Data Mapping
+
+The nullability of a column is based on the optionality of the
+corresponding fields in the schema.
+
+The default values for columns are based on the default values of the
+corresponding fields in the schema.
+
+The following mappings from Connect schema types to database-specific
+types are used.
+
+| Connect schema type |         DB2         |        Derby        |        MySQL        |
+|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
+|        `INT8`       |      `SMALLINT`     |      `SMALLINT`     |      `TINYINT`      |
+|       `INT16`       |      `SMALLINT`     |      `SMALLINT`     |      `SMALLINT`     |
+|       `INT32`       |      `INTEGER`      |      `INTEGER`      |        `INT`        |
+|       `INT64`       |       `BIGINT`      |       `BIGINT`      |       `BIGINT`      |
+|      `FLOAT32`      |       `FLOAT`       |       `FLOAT`       |       `FLOAT`       |
+|      `FLOAT64`      |       `DOUBLE`      |       `DOUBLE`      |       `DOUBLE`      |
+|      `BOOLEAN`      |      `SMALLINT`     |      `SMALLINT`     |      `TINYINT`      |
+|       `STRING`      |   `VARCHAR(32672)`  |   `VARCHAR(32672)`  |    `VARCHAR(256)`   |
+|       `BYTES`       |    `BLOB(64000)`    |    `BLOB(64000)`    |  `VARBINARY(1024)`  |
+|      `Decimal`      | `DECIMAL(31,scale)` | `DECIMAL(31,scale)` | `DECIMAL(65,scale)` |
+|        `Date`       |        `DATE`       |        `DATE`       |        `DATE`       |
+|        `Time`       |        `TIME`       |        `TIME`       |      `TIME(3)`      |
+|     `Timestamp`     |     `TIMESTAMP`     |     `TIMESTAMP`     |    `DATETIME(3)`    |
+
+_(continued)_
+
+| Connect schema type |       Oracle      |     PostgreSQL     |     SAP HANA    |
+|:-------------------:|:-----------------:|:------------------:|:---------------:|
+|        `INT8`       |   `NUMBER(3,0)`   |     `SMALLINT`     |    `TINYINT`    |
+|       `INT16`       |   `NUMBER(5,0)`   |     `SMALLINT`     |    `SMALLINT`   |
+|       `INT32`       |   `NUMBER(10,0)`  |        `INT`       |    `INTEGER`    |
+|       `INT64`       |   `NUMBER(19,0)`  |      `BIGINT`      |     `BIGINT`    |
+|      `FLOAT32`      |   `BINARY_FLOAT`  |       `REAL`       |      `REAL`     |
+|      `FLOAT64`      |  `BINARY_DOUBLE`  | `DOUBLE PRECISION` |     `DOUBLE`    |
+|      `BOOLEAN`      |   `NUMBER(1,0)`   |      `BOOLEAN`     |    `BOOLEAN`    |
+|       `STRING`      |       `CLOB`      |       `TEXT`       | `VARCHAR(1000)` |
+|       `BYTES`       |       `BLOB`      |       `BYTEA`      |      `BLOB`     |
+|      `Decimal`      | `NUMBER(*,scale)` |      `DECIMAL`     |    `DECIMAL`    |
+|        `Date`       |       `DATE`      |       `DATE`       |      `DATE`     |
+|        `Time`       |       `DATE`      |       `TIME`       |      `DATE`     |
+|     `Timestamp`     |    `TIMESTAMP`    |     `TIMESTAMP`    |   `TIMESTAMP`   |
+
+_(continued)_
+
+| Connect schema type |   SQLite  |      SQL Server     |
+|:-------------------:|:---------:|:-------------------:|
+|        `INT8`       | `INTEGER` |      `TINYINT`      |
+|       `INT16`       | `INTEGER` |      `SMALLINT`     |
+|       `INT32`       | `INTEGER` |         `INT`       |
+|       `INT64`       | `INTEGER` |       `BIGINT`      |
+|      `FLOAT32`      |   `REAL`  |        `REAL`       |
+|      `FLOAT64`      |   `REAL`  |       `FLOAT`       |
+|      `BOOLEAN`      | `INTEGER` |        `BIT`        |
+|       `STRING`      |   `TEXT`  |    `VARCHAR(MAX)`   |
+|       `BYTES`       |   `BLOB`  |   `VARBINARY(MAX)`  |
+|      `Decimal`      | `NUMERIC` | `DECIMAL(38,scale)` |
+|        `Date`       | `NUMERIC` |        `DATE`       |
+|        `Time`       | `NUMERIC` |        `TIME`       |
+|     `Timestamp`     | `NUMERIC` |     `DATETIME2`     |
+
+_(continued)_
+
+| Connect schema type |                          Sybase                         |       Vertica       |
+|:-------------------:|:-------------------------------------------------------:|:-------------------:|
+|        `INT8`       |                        `SMALLINT`                       |        `INT`        |
+|       `INT16`       |                        `SMALLINT`                       |        `INT`        |
+|       `INT32`       |                          `INT`                          |        `INT`        |
+|       `INT64`       |                         `BIGINT`                        |        `INT`        |
+|      `FLOAT32`      |                          `REAL`                         |       `FLOAT`       |
+|      `FLOAT64`      |                         `FLOAT`                         |       `FLOAT`       |
+|      `BOOLEAN`      |       `TINYINT` (nullable) or `BIT` (non-nullable)      |      `BOOLEAN`      |
+|       `STRING`      | `VARCHAR(512)` (primary keys) or `TEXT` (other columns) |   `VARCHAR(1024)`   |
+|       `BYTES`       |                         `IMAGE`                         |  `VARBINARY(1024)`  |
+|      `Decimal`      |                   `DECIMAL(38,scale)`                   | `DECIMAL(38,scale)` |
+|        `Date`       |                          `DATE`                         |        `DATE`       |
+|        `Time`       |                          `TIME`                         |        `TIME`       |
+|     `Timestamp`     |                        `DATETIME`                       |      `DATETIME`     |

--- a/docs/source-connector-config-options.rst
+++ b/docs/source-connector-config-options.rst
@@ -1,0 +1,220 @@
+===========================================
+JDBC Source connector Configuration Options
+===========================================
+
+Database
+^^^^^^^^
+
+``connection.url``
+  JDBC connection URL.
+
+  * Type: string
+  * Importance: high
+  * Dependents: ``table.whitelist``, ``table.blacklist``
+
+``connection.user``
+  JDBC connection user.
+
+  * Type: string
+  * Default: null
+  * Importance: high
+
+``connection.password``
+  JDBC connection password.
+
+  * Type: password
+  * Default: null
+  * Importance: high
+
+``connection.attempts``
+  Maximum number of attempts to retrieve a valid JDBC connection.
+
+  * Type: int
+  * Default: 3
+  * Importance: low
+
+``connection.backoff.ms``
+  Backoff time in milliseconds between connection attempts.
+
+  * Type: long
+  * Default: 10000
+  * Importance: low
+
+``table.whitelist``
+  List of tables to include in copying. If specified, table.blacklist may not be set.
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
+``table.blacklist``
+  List of tables to exclude from copying. If specified, table.whitelist may not be set.
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
+``catalog.pattern``
+  Catalog pattern to fetch table metadata from the database:
+
+    * "" retrieves those without a catalog,  * null (default) means that the catalog name should not be used to narrow the search so that all table metadata would be fetched, regardless of their catalog.
+
+  * Type: string
+  * Default: null
+  * Importance: medium
+
+``schema.pattern``
+  Schema pattern to fetch table metadata from the database:
+
+    * "" retrieves those without a schema,  * null (default) means that the schema name should not be used to narrow the search, so that all table metadata would be fetched, regardless of their schema.
+
+  * Type: string
+  * Default: null
+  * Importance: medium
+
+``numeric.precision.mapping``
+  Whether or not to attempt mapping NUMERIC values by precision to integral types. This option is now deprecated. A future version may remove it completely. Please use ``numeric.mapping`` instead.
+
+  * Type: boolean
+  * Default: false
+  * Importance: low
+
+``numeric.mapping``
+  Map NUMERIC values by precision and optionally scale to integral or decimal types. Use ``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL logical type. Use ``best_fit`` if NUMERIC columns should be cast to Connect's INT8, INT16, INT32, INT64, or FLOAT64 based upon the column's precision and scale. Or use ``precision_only`` to map NUMERIC columns based only on the column's precision assuming that column's scale is 0. The ``none`` option is the default, but may lead to serialization issues with Avro since Connect's DECIMAL type is mapped to its binary representation, and ``best_fit`` will often be preferred since it maps to the most appropriate primitive type.
+
+  * Type: string
+  * Default: null
+  * Valid Values: [none, precision_only, best_fit]
+  * Importance: low
+
+``db.timezone``
+  Name of the JDBC timezone that should be used in the connector when querying with time-based criteria. Defaults to UTC.
+
+  * Type: string
+  * Default: UTC
+  * Valid Values: valid time zone identifier (e.g., 'Europe/Helsinki', 'UTC+2', 'Z', 'CET')
+  * Importance: medium
+
+``dialect.name``
+  The name of the database dialect that should be used for this connector. By default this is empty, and the connector automatically determines the dialect based upon the JDBC connection URL. Use this if you want to override that behavior and use a specific dialect. All properly-packaged dialects in the JDBC connector plugin can be used.
+
+  * Type: string
+  * Default: ""
+  * Valid Values: [, Db2DatabaseDialect, MySqlDatabaseDialect, SybaseDatabaseDialect, GenericDatabaseDialect, OracleDatabaseDialect, SqlServerDatabaseDialect, PostgreSqlDatabaseDialect, SqliteDatabaseDialect, DerbyDatabaseDialect, SapHanaDatabaseDialect, VerticaDatabaseDialect]
+  * Importance: low
+
+``sql.quote.identifiers``
+  Whether to delimit (in most databases, quote with double quotes) identifiers (e.g., table names and column names) in SQL statements.
+
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
+Mode
+^^^^
+
+``mode``
+  The mode for updating a table each time it is polled. Options include:
+
+    * bulk - perform a bulk load of the entire table each time it is polled
+
+    * incrementing - use a strictly incrementing column on each table to detect only new rows. Note that this will not detect modifications or deletions of existing rows.
+
+    * timestamp - use a timestamp (or timestamp-like) column to detect new and modified rows. This assumes the column is updated with each write, and that values are monotonically incrementing, but not necessarily unique.
+
+    * timestamp+incrementing - use two columns, a timestamp column that detects new and modified rows and a strictly incrementing column which provides a globally unique ID for updates so each row can be assigned a unique stream offset.
+
+  * Type: string
+  * Valid Values: [bulk, timestamp, incrementing, timestamp+incrementing]
+  * Importance: high
+  * Dependents: ``incrementing.column.name``, ``timestamp.column.name``, ``validate.non.null``
+
+``incrementing.column.name``
+  The name of the strictly incrementing column to use to detect new rows. Any empty value indicates the column should be autodetected by looking for an auto-incrementing column. This column may not be nullable.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
+``timestamp.column.name``
+  Comma separated list of one or more timestamp columns to detect new or modified rows using the COALESCE SQL function. Rows whose first non-null timestamp value is greater than the largest previous timestamp value seen will be discovered with each poll. At least one column should not be nullable.
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
+``validate.non.null``
+  By default, the JDBC connector will validate that all incrementing and timestamp tables have NOT NULL set for the columns being used as their ID/timestamp. If the tables don't, JDBC connector will fail to start. Setting this to false will disable these checks.
+
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
+``query``
+  If specified, the query to perform to select new or updated rows. Use this setting if you want to join tables, select subsets of columns in a table, or filter data. If used, this connector will only copy data using this query -- whole-table copying will be disabled. Different query modes may still be used for incremental updates, but in order to properly construct the incremental query, it must be possible to append a WHERE clause to this query (i.e. no WHERE clauses may be used). If you use a WHERE clause, it must handle incremental queries itself.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
+Connector
+^^^^^^^^^
+
+``table.types``
+  By default, the JDBC connector will only detect tables with type TABLE from the source Database. This config allows a command separated list of table types to extract. Options include:
+
+  * TABLE
+
+  * VIEW
+
+  * SYSTEM TABLE
+
+  * GLOBAL TEMPORARY
+
+  * LOCAL TEMPORARY
+
+  * ALIAS
+
+  * SYNONYM
+
+  In most cases it only makes sense to have either TABLE or VIEW.
+
+  * Type: list
+  * Default: TABLE
+  * Importance: low
+
+``poll.interval.ms``
+  Frequency in ms to poll for new data in each table.
+
+  * Type: int
+  * Default: 5000
+  * Importance: high
+
+``batch.max.rows``
+  Maximum number of rows to include in a single batch when polling for new data. This setting can be used to limit the amount of data buffered internally in the connector.
+
+  * Type: int
+  * Default: 100
+  * Importance: low
+
+``table.poll.interval.ms``
+  Frequency in ms to poll for new or removed tables, which may result in updated task configurations to start polling for data in added tables or stop polling for data in removed tables.
+
+  * Type: long
+  * Default: 60000
+  * Importance: low
+
+``topic.prefix``
+  Prefix to prepend to table names to generate the name of the Kafka topic to publish data to, or in the case of a custom query, the full name of the topic to publish to.
+
+  * Type: string
+  * Importance: high
+
+``timestamp.delay.interval.ms``
+  How long to wait after a row with certain timestamp appears before we include it in the result. You may choose to add some delay to allow transactions with earlier timestamp to complete. The first execution will fetch all available records (i.e. starting at timestamp 0) until current time minus the delay. Every following execution will get data from the last time we fetched until current time minus the delay.
+
+  * Type: long
+  * Default: 0
+  * Importance: high
+
+

--- a/docs/source-connector.md
+++ b/docs/source-connector.md
@@ -1,0 +1,261 @@
+# Kafka Connect JDBC Source Connector
+
+This [Kafka Connect](https://kafka.apache.org/documentation/#connect)
+connector allows you to transfer data from a relational database into
+Apache Kafka topics.
+
+[Full configuration options reference](source-connector-config-options.rst).
+
+## How It Works
+
+The connector works with multiple data sources (tables, views; a custom
+query) in the database. For each data source, there is a corresponding
+Kafka topic.
+
+The connector connects to the database and periodically queries its data
+sources. The poll interval is configured by `poll.interval.ms` and is 5
+seconds by default.
+
+Each row from the database response is transformed into a record and
+published into the corresponding Kafka topic.
+
+## Database
+
+### Connection
+
+The connector is instructed how to connect to the database using
+`connection.url`, `connection.user` and `connection.password`
+configurations.
+
+Some database drivers support SSL encryption of the connection, which is
+configured with the connection URL as well.
+
+The format of the connection URL is specific to the database driver.
+Here are some documentations:
+- [for PostgreSQL](https://jdbc.postgresql.org/documentation/head/connect.html);
+- [for MySQL](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html);
+- [for MariaDB](https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings);
+- [for SQLite](http://www.sqlitetutorial.net/sqlite-java/sqlite-jdbc-driver/);
+- [for Derby](https://db.apache.org/derby/docs/10.15/devguide/cdevdvlp17453.html).
+
+For example, for PostgreSQL the connection URL might look like
+```
+jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true
+```
+
+### SQL Dialects
+
+Different databases use different dialects of SQL. The connector
+supports several of them.
+
+By default, the connector will automatically determine the dialect based
+on the connection URL (`connection.url`).
+
+If needed, it's possible to specify the dialect explicitly using
+`dialect.name` configuration. Check
+[the configuration's reference](source-connector-config-options.rst#database)
+for the list of supported dialects.
+
+## Data Sources
+
+The connector can be configured to work with two types of data sources:
+- tables (including other database objects like views, synonyms, etc.);
+- a custom `SELECT` query.
+
+### Tables
+
+By default, the connector works only with tables, considering all tables
+in all catalogs and schemas. This can be changed in several ways:
+
+1. By limiting the table discovery to a particular catalog by setting
+   `catalog.pattern` configuration.
+2. By limiting the table discovery to some schemas by setting
+   `schema.pattern` configuration.
+3. By limiting the table discovery with a whitelist or a blacklist by
+   setting `table.whitelist` or `table.blacklist` configuration.
+4. By changing the types of tables to be considered by setting
+   `table.types` configuration (e.g., to use database views).
+
+The connector periodically polls the database metadata, detects created
+and deleted tables. It automatically adapts to these changes by starting
+polling created tables and stopping deleted ones. The metadata poll
+interval is configured by `table.poll.interval.ms` and is 60 seconds by
+default.
+
+### Custom Query
+
+Instead of relying on data source discovery, it is possible to set a
+custom query to be executed by the connector. This may be useful if
+joining tables or selecting a subset of columns is needed.
+
+If the connector works in one of the
+[incremental modes](#incremental-modes), it must be possible to append
+`WHERE` clause to the query.
+
+Currently, only one custom query at a time is supported.
+
+#### Warning: Changing the Query And Stored Timestamps
+
+With a custom query in an incremental mode, the processed timestamps are
+stored independently on the query text itself. It means if the query is
+modified in incompatible way (e.g., when a new query uses completely
+different tables), the previously stored timestamps will still be used
+on the next run of the connector.
+
+It's possible to solve this either by manually deleting or altering the
+stored offsets or by using a different connector name when the custom
+query text is changed in an incompatible way.
+
+## Kafka Topics
+
+When the connector uses database tables as the data source, it maps each
+table to the corresponding Kafka topic as `<prefix><table_name>`.
+
+If the connector is configured to use a custom query, the topic name is
+just `<prefix>`.
+
+The prefix must be specified, set `topic.prefix=<prefix here>` for this.
+
+## Query Modes
+
+The connector has four query modes, the _bulk mode_, and three
+_incremental modes_.
+
+### Bulk Mode
+
+In this mode, the connector will query tables without any filtering,
+periodically retrieving all rows from them and publishing them to Kafka.
+
+To use this mode, set `mode=bulk`.
+
+### Incremental Modes
+
+In these modes, the connector keeps track of the latest rows it has
+already processed in each table and retrieves only rows that were added
+or updated after those.
+
+The incremental query modes use certain columns to discover created or
+updated rows. To make polling done by the connector efficient, it is
+advisable to have these columns indexed.
+
+#### Incremental Mode With Incrementing Column
+
+In this mode, tables are supposed to have a numeric column containing
+sequentially growing numbers. Normally, this is a unique ID column with
+automatically generated values, like `AUTO_INCREMENT` columns from MySQL
+or sequential columns from PostgreSQL.
+
+Normally updates do not change row IDs. Because of this, the connector
+will detect only newly created rows. This makes this mode most suitable
+for streaming immutable rows that are added to a table, for example, for
+streaming facts from a fact table.
+
+To use this mode, set `mode=incrementing`. Use 
+`incrementing.column.name` for setting the incrementing column name.
+
+#### Incremental Mode With Timestamp Column
+
+In this mode, tables are supposed to have one or many timestamp columns.
+The connector will apply `COALESCE` SQL function to them to get one
+timestamp for a row. Rows with this timestamp greater than the largest
+previously known will be retrieved on the next query.
+
+An example use case might be streaming of rows that have `created_at`
+and `updated_at` timestamps. When a row is created, it will be retrieved
+for the first time. Later, when it is modified with updating the
+`updated_at` timestamp, it will be retrieved again.
+
+Sometimes it is necessary to introduce a delay between creation or
+update of a row and its publishing to a topic. This delay can be set
+using `timestamp.delay.interval.ms` configuration.
+
+**Note:** Timestamps are not necessarily unique. This might cause the
+following problematic situation. Two rows `R1` and `R2` share the same
+timestamp `T` and have been retrieved from the database. However, only
+`R1` has been written to a topic before a crash, but the timestamp `T`
+has been persisted anyway. On the next poll, rows with timestamp `T`,
+including `R2` will not be retrieved, leaving `R2` unprocessed. This
+problem is addressed by the [incremental mode with incrementing and
+timestamp columns](#incremental-mode-with-incrementing-and-timestamp-columns).
+
+To use this mode, set `mode=timestamp`. Use `timestamp.column.name` for
+setting the list of the timestamp column names.
+
+#### Incremental Mode With Incrementing and Timestamp Columns
+
+This mode is a combination of incremental modes with incrementing column
+and timestamp columns, a more accurate and robust.
+
+The mode is similar to the incremental mode with timestamp columns. The
+only difference is that the controller in this mode uses incrementing
+IDs along with timestamps to detect rows to be processed and processes
+rows in the order of the timestamp _and_ the incrementing ID.
+
+Unlike the incremental mode with timestamp columns, this mode is not
+susceptible to the issue of a partial processing of rows with shared
+timestamps.
+
+Unlike the incremental mode with incrementing column, this mode allows
+retrieving rows that have been updated.
+
+To use this mode, set `mode=timestamp+incrementing`. Use
+`timestamp.column.name` for setting the list of the timestamp column
+names and `incrementing.column.name` for setting the incrementing column
+name.
+
+## Mapping Column Types
+
+The connector maps SQL types to the most accurate representation in
+Java.
+
+### Mapping of `NUMERIC` And `DECIMAL`
+
+`NUMERIC` and `DECIMAL` SQL types are naturally mapped into Connect
+`Decimal` type (which is logically represented by Java `BigDecimal`
+type). However, Avro serializes `Decimal`s as raw bytes, which may be
+inconvenient to consume.
+
+To fix this potential issue, the connector has several approaches to
+mapping `NUMERIC` And `DECIMAL` to Connect types.
+
+#### Always `Decimal`
+
+This is the straightforward mapping from `NUMERIC` and `DECIMAL` SQL
+types into `Decimal` Connect type.
+
+This is the default behavior. To enable it explicitly, set
+`numeric.mapping=none`.
+
+#### Best Fit
+
+In this mode, the connector will first try to find the appropriate
+representation among the primitive Connect types before defaulting to
+`Decimal`. The decision is based on the precision and scale.
+
+| Precision |   Scale  | Connect "best fit" primitive type |
+|:---------:|:--------:|:---------------------------------:|
+|   1 to 2  | -84 to 0 |               `INT8`              |
+|   3 to 4  | -84 to 0 |              `INT16`              |
+|   5 to 9  | -84 to 0 |              `INT32`              |
+|  10 to 18 | -84 to 0 |              `INT64`              |
+|  1 to 18  | positive |             `FLOAT64`             |
+|   other   |   other  |             `Decimal`             |
+
+To use this mode, set `numeric.mapping=best_fit`.
+
+#### Precision Only
+
+In this mode, the connector will first try to find the appropriate
+representation among the primitive Connect types before defaulting to
+`Decimal`. The decision is based on the precision only, while the scale
+is always 0.
+
+| Precision | Scale | Connect "best fit" primitive type |
+|:---------:|:-----:|:---------------------------------:|
+|   1 to 2  |   0   |               `INT8`              |
+|   3 to 4  |   0   |              `INT16`              |
+|   5 to 9  |   0   |              `INT32`              |
+|  10 to 18 |   0   |              `INT64`              |
+|   other   | other |             `Decimal`             |
+
+To use this mode, set `numeric.mapping=precision_only`.

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -366,6 +366,10 @@ public class JdbcSinkConfig extends JdbcConfig {
     }
 
     public static void main(final String... args) {
+        System.out.println("=========================================");
+        System.out.println("JDBC Sink connector Configuration Options");
+        System.out.println("=========================================");
+        System.out.println();
         System.out.println(CONFIG_DEF.toEnrichedRst());
     }
 }

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -714,6 +714,10 @@ public class JdbcSourceConnectorConfig extends JdbcConfig {
     }
 
     public static void main(final String[] args) {
+        System.out.println("===========================================");
+        System.out.println("JDBC Source connector Configuration Options");
+        System.out.println("===========================================");
+        System.out.println();
         System.out.println(CONFIG_DEF.toEnrichedRst());
     }
 }


### PR DESCRIPTION
This commit adds the connector documentation:
 - Adds hand-written documentation for Source and Sink (
   `source-connector.md` and `sink-connector.md`);
 - Adds Gradle task for configuration reference generation and checks
   in the currently generated files (
   `source-connector-config-options.rst` and
   `sink-connector-config-options.rst`)