### PR TITLE
Output properly filled version file in build JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,12 @@ dependencies {
     testRuntime "org.slf4j:slf4j-log4j12:$slf4jVersion"
 }
 
+processResources {
+    filesMatching('kafka-connect-jdbc-version.properties') {
+        expand(version: version)
+    }
+}
+
 task connectorConfigDoc {
     description = "Generates the connector's configuration documentation."
     group = "documentation"

--- a/src/main/resources/kafka-connect-jdbc-version.properties
+++ b/src/main/resources/kafka-connect-jdbc-version.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 ##
 
-version=${project.version}
+version=${version ?: 'unknown'}


### PR DESCRIPTION
This commit makes Gradle to properly put the version number into
`kafka-conncet-jdbc-version.properties` during the build/JAR packaging.