### PR TITLE
#35: table name normalization

### DIFF
--- a/checkstyle/java.header
+++ b/checkstyle/java.header
@@ -1,5 +1,5 @@
 /\*
- \* Copyright 2019 Aiven Oy
+ \* Copyright 20(19|2[0-9]) Aiven Oy
  \* Copyright 201[5-9] Confluent Inc.
  \*
  \* Licensed under the Apache License, Version 2.0 \(the "License"\);

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -91,6 +91,13 @@ Data Mapping
   * Default: ${topic}
   * Importance: medium
 
+``table.name.normalize``
+  Whether or not to normalize destination table names for topics. When set to ``true``, the alphanumeric characters (``a-z A-Z 0-9``) and ``_`` remain as is, others (like ``.``) are replaced with ``_``.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
 ``pk.mode``
   The primary key mode, also refer to ``pk.fields`` documentation for interplay. Supported modes are:
 

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcDbWriter.java
@@ -38,7 +38,7 @@ public class JdbcDbWriter {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
 
-    private static final Pattern NORMALIZE_TABLE_NAME_FOR_TOPIC = Pattern.compile("(?<!^)[^a-zA-Z0-9_-]");
+    private static final Pattern NORMALIZE_TABLE_NAME_FOR_TOPIC = Pattern.compile("[^a-zA-Z0-9_]");
 
     private final JdbcSinkConfig config;
 
@@ -103,7 +103,9 @@ public class JdbcDbWriter {
 
     public String generateTableNameFor(final String topic) {
         final String tableName = config.tableNameFormat.replace("${topic}", topic);
-        return NORMALIZE_TABLE_NAME_FOR_TOPIC.matcher(tableName).replaceAll("_");
+        return config.tableNameNormalize
+                ? NORMALIZE_TABLE_NAME_FOR_TOPIC.matcher(tableName).replaceAll("_")
+                : tableName;
     }
 
 }

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -57,7 +57,7 @@ public class JdbcSinkConfig extends JdbcConfig {
     );
 
     public static final String TABLE_NAME_FORMAT = "table.name.format";
-    public static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
+    private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
     private static final String TABLE_NAME_FORMAT_DOC =
         "A format string for the destination table name, which may contain '${topic}' as a "
             + "placeholder for the originating topic name.\n"
@@ -68,10 +68,9 @@ public class JdbcSinkConfig extends JdbcConfig {
     public static final String TABLE_NAME_NORMALIZE = "table.name.normalize";
     public static final boolean TABLE_NAME_NORMALIZE_DEFAULT = false;
     private static final String TABLE_NAME_NORMALIZE_DOC =
-            "If set to ``true`` the alphanumeric characters (``a-z A-Z 0-9``) and ``_`` "
-                    + "in the destination table name for the particular topic will remain as is, "
-                    + "others (like ``.``) will be replaced by ``_``. "
-                    + "By default is set to ``false``.";
+            "Whether or not to normalize destination table names for topics. "
+                    + "When set to ``true``, the alphanumeric characters (``a-z A-Z 0-9``) and ``_`` "
+                    + "remain as is, others (like ``.``) are replaced with ``_``.";
     private static final String TABLE_NAME_NORMALIZE_DISPLAY = "Table Name Normalize";
 
     public static final String MAX_RETRIES = "max.retries";
@@ -225,7 +224,7 @@ public class JdbcSinkConfig extends JdbcConfig {
                 TABLE_NAME_NORMALIZE,
                 ConfigDef.Type.BOOLEAN,
                 TABLE_NAME_NORMALIZE_DEFAULT,
-                ConfigDef.Importance.MEDIUM,
+                ConfigDef.Importance.LOW,
                 TABLE_NAME_NORMALIZE_DOC,
                 DATAMAPPING_GROUP,
                 2,

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2020 Aiven Oy
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,6 @@ import java.util.TimeZone;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.types.Password;
 
 import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.StringUtils;
@@ -58,12 +57,15 @@ public class JdbcSinkConfig extends JdbcConfig {
     );
 
     public static final String TABLE_NAME_FORMAT = "table.name.format";
-    private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
+
+    public static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
+
     private static final String TABLE_NAME_FORMAT_DOC =
         "A format string for the destination table name, which may contain '${topic}' as a "
             + "placeholder for the originating topic name.\n"
             + "For example, ``kafka_${topic}`` for the topic 'orders' will map to the table name "
-            + "'kafka_orders'.";
+            + "'kafka_orders'. The alphanumeric characters (``a-z A-Z 0-9``) and ``_`` "
+            + "will remain as is, others (like ``.``) will be replaced by ``_``.";
     private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
 
     public static final String MAX_RETRIES = "max.retries";
@@ -322,14 +324,6 @@ public class JdbcSinkConfig extends JdbcConfig {
         fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
         final String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
         timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
-    }
-
-    private String getPasswordValue(final String key) {
-        final Password password = getPassword(key);
-        if (password != null) {
-            return password.value();
-        }
-        return null;
     }
 
     private static class EnumValidator implements ConfigDef.Validator {

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -57,16 +57,22 @@ public class JdbcSinkConfig extends JdbcConfig {
     );
 
     public static final String TABLE_NAME_FORMAT = "table.name.format";
-
     public static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
-
     private static final String TABLE_NAME_FORMAT_DOC =
         "A format string for the destination table name, which may contain '${topic}' as a "
             + "placeholder for the originating topic name.\n"
             + "For example, ``kafka_${topic}`` for the topic 'orders' will map to the table name "
-            + "'kafka_orders'. The alphanumeric characters (``a-z A-Z 0-9``) and ``_`` "
-            + "will remain as is, others (like ``.``) will be replaced by ``_``.";
+            + "'kafka_orders'.";
     private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
+
+    public static final String TABLE_NAME_NORMALIZE = "table.name.normalize";
+    public static final boolean TABLE_NAME_NORMALIZE_DEFAULT = false;
+    private static final String TABLE_NAME_NORMALIZE_DOC =
+            "If set to ``true`` the alphanumeric characters (``a-z A-Z 0-9``) and ``_`` "
+                    + "in the destination table name for the particular topic will remain as is, "
+                    + "others (like ``.``) will be replaced by ``_``. "
+                    + "By default is set to ``false``.";
+    private static final String TABLE_NAME_NORMALIZE_DISPLAY = "Table Name Normalize";
 
     public static final String MAX_RETRIES = "max.retries";
     private static final int MAX_RETRIES_DEFAULT = 10;
@@ -216,6 +222,17 @@ public class JdbcSinkConfig extends JdbcConfig {
                 TABLE_NAME_FORMAT_DISPLAY
             )
             .define(
+                TABLE_NAME_NORMALIZE,
+                ConfigDef.Type.BOOLEAN,
+                TABLE_NAME_NORMALIZE_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                TABLE_NAME_NORMALIZE_DOC,
+                DATAMAPPING_GROUP,
+                2,
+                ConfigDef.Width.LONG,
+                TABLE_NAME_NORMALIZE_DISPLAY
+            )
+            .define(
                 PK_MODE,
                 ConfigDef.Type.STRING,
                 PK_MODE_DEFAULT,
@@ -223,7 +240,7 @@ public class JdbcSinkConfig extends JdbcConfig {
                 ConfigDef.Importance.HIGH,
                 PK_MODE_DOC,
                 DATAMAPPING_GROUP,
-                2,
+                3,
                 ConfigDef.Width.MEDIUM,
                 PK_MODE_DISPLAY
             )
@@ -234,7 +251,7 @@ public class JdbcSinkConfig extends JdbcConfig {
                 ConfigDef.Importance.MEDIUM,
                 PK_FIELDS_DOC,
                 DATAMAPPING_GROUP,
-                3,
+                4,
                 ConfigDef.Width.LONG, PK_FIELDS_DISPLAY
             )
             .define(
@@ -244,7 +261,7 @@ public class JdbcSinkConfig extends JdbcConfig {
                 ConfigDef.Importance.MEDIUM,
                 FIELDS_WHITELIST_DOC,
                 DATAMAPPING_GROUP,
-                4,
+                5,
                 ConfigDef.Width.LONG,
                 FIELDS_WHITELIST_DISPLAY
             );
@@ -299,6 +316,7 @@ public class JdbcSinkConfig extends JdbcConfig {
     }
 
     public final String tableNameFormat;
+    public final boolean tableNameNormalize;
     public final int batchSize;
     public final int maxRetries;
     public final int retryBackoffMs;
@@ -313,6 +331,7 @@ public class JdbcSinkConfig extends JdbcConfig {
     public JdbcSinkConfig(final Map<?, ?> props) {
         super(CONFIG_DEF, props);
         tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
+        tableNameNormalize = getBoolean(TABLE_NAME_NORMALIZE);
         batchSize = getInt(BATCH_SIZE);
         maxRetries = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -79,20 +79,23 @@ public class JdbcDbWriterTest {
 
     @Test
     public void shouldGenerateNormalizedTableNameForTopic() {
-
-        final Map<String, String> props = new HashMap<>();
+        final Map<String, Object> props = new HashMap<>();
         props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhost");
         props.put(JdbcSinkConfig.TABLE_NAME_FORMAT, "kafka_topic_${topic}");
+        props.put(JdbcSinkConfig.TABLE_NAME_NORMALIZE, true);
         final JdbcSinkConfig jdbcSinkConfig = new JdbcSinkConfig(props);
 
         dialect = new SqliteDatabaseDialect(jdbcSinkConfig);
         final DbStructure dbStructure = new DbStructure(dialect);
         final JdbcDbWriter jdbcDbWriter = new JdbcDbWriter(jdbcSinkConfig, dialect, dbStructure);
 
+        assertEquals("kafka_topic___some_topic",
+                jdbcDbWriter.generateTableNameFor("--some_topic"));
+
         assertEquals("kafka_topic_some_topic",
                 jdbcDbWriter.generateTableNameFor("some_topic"));
 
-        assertEquals("kafka_topic_some-topic",
+        assertEquals("kafka_topic_some_topic",
                 jdbcDbWriter.generateTableNameFor("some-topic"));
 
         assertEquals("kafka_topic_this_is_topic_with_dots",
@@ -104,25 +107,6 @@ public class JdbcDbWriterTest {
         assertEquals("kafka_topic_orders_topic__3",
                 jdbcDbWriter.generateTableNameFor("orders_topic_#3"));
 
-    }
-
-
-    @Test
-    public void shouldGetNormalizedTableName() {
-        final Map<String, String> props = new HashMap<>();
-        props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhnost");
-        props.put(JdbcSinkConfig.TABLE_NAME_FORMAT, "${topic}");
-
-        final JdbcSinkConfig jdbcSinkConfig = new JdbcSinkConfig(props);
-        dialect = new SqliteDatabaseDialect(jdbcSinkConfig);
-        final DbStructure dbStructure = new DbStructure(dialect);
-        final JdbcDbWriter writer = new JdbcDbWriter(jdbcSinkConfig, dialect, dbStructure);
-
-        TableId tableId = writer.destinationTable("this.is.my.topic");
-        assertEquals("this_is_my_topic", tableId.tableName());
-
-        tableId = writer.destinationTable("the_topic");
-        assertEquals("the_topic", tableId.tableName());
     }
 
     @Test

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2020 Aiven Oy
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,6 +75,54 @@ public class JdbcDbWriterTest {
         dialect = new SqliteDatabaseDialect(config);
         final DbStructure dbStructure = new DbStructure(dialect);
         return new JdbcDbWriter(config, dialect, dbStructure);
+    }
+
+    @Test
+    public void shouldGenerateNormalizedTableNameForTopic() {
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhost");
+        props.put(JdbcSinkConfig.TABLE_NAME_FORMAT, "kafka_topic_${topic}");
+        final JdbcSinkConfig jdbcSinkConfig = new JdbcSinkConfig(props);
+
+        dialect = new SqliteDatabaseDialect(jdbcSinkConfig);
+        final DbStructure dbStructure = new DbStructure(dialect);
+        final JdbcDbWriter jdbcDbWriter = new JdbcDbWriter(jdbcSinkConfig, dialect, dbStructure);
+
+        assertEquals("kafka_topic_some_topic",
+                jdbcDbWriter.generateTableNameFor("some_topic"));
+
+        assertEquals("kafka_topic_some-topic",
+                jdbcDbWriter.generateTableNameFor("some-topic"));
+
+        assertEquals("kafka_topic_this_is_topic_with_dots",
+                jdbcDbWriter.generateTableNameFor("this.is.topic.with.dots"));
+
+        assertEquals("kafka_topic_this_is_topic_with_dots_and_weired_characters___",
+                jdbcDbWriter.generateTableNameFor("this.is.topic.with.dots.and.weired.characters#$%"));
+
+        assertEquals("kafka_topic_orders_topic__3",
+                jdbcDbWriter.generateTableNameFor("orders_topic_#3"));
+
+    }
+
+
+    @Test
+    public void shouldGetNormalizedTableName() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhnost");
+        props.put(JdbcSinkConfig.TABLE_NAME_FORMAT, "${topic}");
+
+        final JdbcSinkConfig jdbcSinkConfig = new JdbcSinkConfig(props);
+        dialect = new SqliteDatabaseDialect(jdbcSinkConfig);
+        final DbStructure dbStructure = new DbStructure(dialect);
+        final JdbcDbWriter writer = new JdbcDbWriter(jdbcSinkConfig, dialect, dbStructure);
+
+        TableId tableId = writer.destinationTable("this.is.my.topic");
+        assertEquals("this_is_my_topic", tableId.tableName());
+
+        tableId = writer.destinationTable("the_topic");
+        assertEquals("the_topic", tableId.tableName());
     }
 
     @Test


### PR DESCRIPTION
This PR:
- Adds the configuration `table.name.normalize`.
- If `table.name.normalize` is enabled, makes all non `A-Za-z0-9_` characters in target table names be replaced with `_`.
- Adds some tests for this.

https://github.com/aiven/aiven-kafka-connect-jdbc/issues/35