### PR TITLE
Redshift dialect with multi-row insert

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -38,7 +38,7 @@ Database
 
   * Type: string
   * Default: ""
-  * Valid Values: [, Db2DatabaseDialect, MySqlDatabaseDialect, SybaseDatabaseDialect, GenericDatabaseDialect, OracleDatabaseDialect, SqlServerDatabaseDialect, PostgreSqlDatabaseDialect, SqliteDatabaseDialect, DerbyDatabaseDialect, SapHanaDatabaseDialect, VerticaDatabaseDialect]
+  * Valid Values: [, Db2DatabaseDialect, MySqlDatabaseDialect, SybaseDatabaseDialect, GenericDatabaseDialect, OracleDatabaseDialect, SqlServerDatabaseDialect, PostgreSqlDatabaseDialect, SqliteDatabaseDialect, DerbyDatabaseDialect, SapHanaDatabaseDialect, VerticaDatabaseDialect, RedshiftDatabaseDialect]
   * Importance: low
 
 ``sql.quote.identifiers``
@@ -58,6 +58,10 @@ Writes
 
       Use standard SQL ``INSERT`` statements.
 
+  ``multi``
+
+      Use multi-row inserts, e.g. ``INSERT INTO table_name (column_list) VALUES (value_list_1), (value_list_2), ... (value_list_n);``
+
   ``upsert``
 
       Use the appropriate upsert semantics for the target database if it is supported by the connector, e.g. ``INSERT .. ON CONFLICT .. DO UPDATE SET ..``.
@@ -68,7 +72,7 @@ Writes
 
   * Type: string
   * Default: insert
-  * Valid Values: [insert, upsert, update]
+  * Valid Values: [insert, multi, upsert, update]
   * Importance: high
 
 ``batch.size``

--- a/docs/sink-connector.md
+++ b/docs/sink-connector.md
@@ -77,6 +77,13 @@ from Kafka.
 This mode is used by default. To enable it explicitly, set
 `insert.mode=insert`.
 
+### Multi Mode
+
+In this mode, the connector executes an `INSERT` SQL query with multiple
+values (effectively inserting multiple row/records per query).
+
+To use this mode, set `insert.mode=multi`
+
 ### Update Mode
 
 In this mode, the connector executes `UPDATE` SQL query on each record

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
@@ -324,6 +324,18 @@ public interface DatabaseDialect extends ConnectionProvider {
         Collection<ColumnId> nonKeyColumns
     );
 
+    String buildFirstMultiInsertStatement(
+            TableId tableId,
+            Collection<ColumnId> keyColumns,
+            Collection<ColumnId> nonKeyColumns
+    );
+
+    String buildMultiInsertStatement(
+            TableId tableId,
+            Collection<ColumnId> keyColumns,
+            Collection<ColumnId> nonKeyColumns
+    );
+
     /**
      * Build the UPDATE prepared statement expression for the given table and its columns. Variables
      * for each key column should also appear in the WHERE clause of the statement.
@@ -423,6 +435,8 @@ public interface DatabaseDialect extends ConnectionProvider {
         Schema schema,
         Object value
     ) throws SQLException;
+
+
 
     /**
      * A function to bind the values from a sink record into a prepared statement.

--- a/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1351,6 +1351,24 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
 
     @Override
+    public String buildFirstMultiInsertStatement(
+            final TableId table,
+            final Collection<ColumnId> keyColumns,
+            final Collection<ColumnId> nonKeyColumns
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String buildMultiInsertStatement(
+            final TableId table,
+            final Collection<ColumnId> keyColumns,
+            final Collection<ColumnId> nonKeyColumns
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String buildUpdateStatement(
         final TableId table,
         final Collection<ColumnId> keyColumns,

--- a/src/main/java/io/aiven/connect/jdbc/dialect/RedshiftDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/RedshiftDatabaseDialect.java
@@ -22,7 +22,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -218,6 +221,18 @@ public class RedshiftDatabaseDialect extends GenericDatabaseDialect {
             default:
                 return super.getSqlType(field);
         }
+    }
+
+    @Override
+    public List<String> buildAlterTable(
+            final TableId table,
+            final Collection<SinkRecordField> fields
+    ) {
+        final List<String> queries = new ArrayList<>(fields.size());
+        for (final SinkRecordField field : fields) {
+            queries.addAll(super.buildAlterTable(table, Collections.singleton(field)));
+        }
+        return queries;
     }
 
     @Override

--- a/src/main/java/io/aiven/connect/jdbc/dialect/RedshiftDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/RedshiftDatabaseDialect.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.jdbc.dialect;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collection;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+import io.aiven.connect.jdbc.config.JdbcConfig;
+import io.aiven.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
+import io.aiven.connect.jdbc.source.ColumnMapping;
+import io.aiven.connect.jdbc.util.ColumnDefinition;
+import io.aiven.connect.jdbc.util.ColumnId;
+import io.aiven.connect.jdbc.util.ExpressionBuilder;
+import io.aiven.connect.jdbc.util.IdentifierRules;
+import io.aiven.connect.jdbc.util.TableId;
+
+
+/**
+ * A {@link DatabaseDialect} for Redshift.
+ */
+public class RedshiftDatabaseDialect extends GenericDatabaseDialect {
+
+    /**
+     * The provider for {@link RedshiftDatabaseDialect}.
+     */
+    public static class Provider extends SubprotocolBasedProvider {
+        public Provider() {
+            super(RedshiftDatabaseDialect.class.getSimpleName(), "redshift");
+        }
+
+        @Override
+        public DatabaseDialect create(final JdbcConfig config) {
+            return new RedshiftDatabaseDialect(config);
+        }
+    }
+
+    private static final String JSON_TYPE_NAME = "json";
+    private static final String JSONB_TYPE_NAME = "jsonb";
+
+    /**
+     * Create a new dialect instance with the given connector configuration.
+     *
+     * @param config the connector configuration; may not be null
+     */
+    public RedshiftDatabaseDialect(final JdbcConfig config) {
+        super(config, new IdentifierRules(".", "\"", "\""));
+    }
+
+    /**
+     * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
+     * the {@link #createPreparedStatement(Connection, String)} method after the statement is
+     * created but before it is returned/used.
+     *
+     * <p>This method sets the {@link PreparedStatement#setFetchDirection(int) fetch direction}
+     * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
+     * scroll more efficiently through the result set and prevent out of memory errors.
+     *
+     * @param stmt the prepared statement; never null
+     * @throws SQLException the error that might result from initialization
+     */
+    @Override
+    protected void initializePreparedStatement(final PreparedStatement stmt) throws SQLException {
+        log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+        stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+    }
+
+
+    @Override
+    public String addFieldToSchema(
+        final ColumnDefinition columnDefn,
+        final SchemaBuilder builder
+    ) {
+        // Add the PostgreSQL-specific types first
+        final String fieldName = fieldNameFor(columnDefn);
+        switch (columnDefn.type()) {
+            case Types.BIT: {
+                // PostgreSQL allows variable length bit strings, but when length is 1 then the driver
+                // returns a 't' or 'f' string value to represent the boolean value, so we need to handle
+                // this as well as lengths larger than 8.
+                final boolean optional = columnDefn.isOptional();
+                final int numBits = columnDefn.precision();
+                final Schema schema;
+                if (numBits <= 1) {
+                    schema = optional ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
+                } else if (numBits <= 8) {
+                    // For consistency with what the connector did before ...
+                    schema = optional ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
+                } else {
+                    schema = optional ? Schema.OPTIONAL_BYTES_SCHEMA : Schema.BYTES_SCHEMA;
+                }
+                builder.field(fieldName, schema);
+                return fieldName;
+            }
+            case Types.OTHER: {
+                // Some of these types will have fixed size, but we drop this from the schema conversion
+                // since only fixed byte arrays can have a fixed size
+                if (isJsonType(columnDefn)) {
+                    builder.field(
+                        fieldName,
+                        columnDefn.isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA
+                    );
+                    return fieldName;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        // Delegate for the remaining logic
+        return super.addFieldToSchema(columnDefn, builder);
+    }
+
+    @Override
+    public ColumnConverter createColumnConverter(
+        final ColumnMapping mapping
+    ) {
+        // First handle any PostgreSQL-specific types
+        final ColumnDefinition columnDefn = mapping.columnDefn();
+        final int col = mapping.columnNumber();
+        switch (columnDefn.type()) {
+            case Types.BIT: {
+                // PostgreSQL allows variable length bit strings, but when length is 1 then the driver
+                // returns a 't' or 'f' string value to represent the boolean value, so we need to handle
+                // this as well as lengths larger than 8.
+                final int numBits = columnDefn.precision();
+                if (numBits <= 1) {
+                    return rs -> rs.getBoolean(col);
+                } else if (numBits <= 8) {
+                    // Do this for consistency with earlier versions of the connector
+                    return rs -> rs.getByte(col);
+                }
+                return rs -> rs.getBytes(col);
+            }
+            case Types.OTHER: {
+                if (isJsonType(columnDefn)) {
+                    return rs -> rs.getString(col);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        // Delegate for the remaining logic
+        return super.createColumnConverter(mapping);
+    }
+
+    protected boolean isJsonType(final ColumnDefinition columnDefn) {
+        final String typeName = columnDefn.typeName();
+        return JSON_TYPE_NAME.equalsIgnoreCase(typeName) || JSONB_TYPE_NAME.equalsIgnoreCase(typeName);
+    }
+
+    @Override
+    protected String getSqlType(final SinkRecordField field) {
+        if (field.schemaName() != null) {
+            switch (field.schemaName()) {
+                case Decimal.LOGICAL_NAME:
+                    return "DECIMAL";
+                case Date.LOGICAL_NAME:
+                    return "DATE";
+                case Time.LOGICAL_NAME:
+                    return "TIME";
+                case Timestamp.LOGICAL_NAME:
+                    return "TIMESTAMP";
+                default:
+                    // fall through to normal types
+            }
+        }
+        switch (field.schemaType()) {
+            case INT8:
+                return "SMALLINT";
+            case INT16:
+                return "SMALLINT";
+            case INT32:
+                return "INT";
+            case INT64:
+                return "BIGINT";
+            case FLOAT32:
+                return "REAL";
+            case FLOAT64:
+                return "DOUBLE PRECISION";
+            case BOOLEAN:
+                return "BOOLEAN";
+            case STRING:
+                // Redshift maps TEXT to VARCHAR(256) which is generally unsuitable. I've arbitrarily chosen 5000 as a
+                // more suitable approximation.
+                return "VARCHAR(5000)";
+            case BYTES:
+                return "BYTEA";
+            default:
+                return super.getSqlType(field);
+        }
+    }
+
+    @Override
+    public String buildInsertStatement(
+            final TableId table,
+            final Collection<ColumnId> keyColumns,
+            final Collection<ColumnId> nonKeyColumns
+    ) {
+        final ExpressionBuilder builder = expressionBuilder();
+        builder.append("INSERT INTO ");
+        builder.append(table);
+        builder.append("(");
+        builder.appendList()
+                .delimitedBy(",")
+                .transformedBy(ExpressionBuilder.columnNames())
+                .of(keyColumns, nonKeyColumns);
+        builder.append(") VALUES(");
+        builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+        builder.append(")");
+        return builder.toString();
+    }
+
+    @Override
+    public String buildFirstMultiInsertStatement(
+            final TableId table,
+            final Collection<ColumnId> keyColumns,
+            final Collection<ColumnId> nonKeyColumns
+    ) {
+        final ExpressionBuilder builder = expressionBuilder();
+        builder.append("INSERT INTO ");
+        builder.append(table);
+        builder.append("(");
+        builder.appendList()
+                .delimitedBy(",")
+                .transformedBy(ExpressionBuilder.columnNames())
+                .of(keyColumns, nonKeyColumns);
+        builder.append(") VALUES(");
+        builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+        builder.append(")");
+        return builder.toString();
+    }
+
+    @Override
+    public String buildMultiInsertStatement(
+            final TableId table,
+            final Collection<ColumnId> keyColumns,
+            final Collection<ColumnId> nonKeyColumns
+    ) {
+        final ExpressionBuilder builder = expressionBuilder();
+        builder.append(",(");
+        builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -38,6 +38,7 @@ public class JdbcSinkConfig extends JdbcConfig {
 
     public enum InsertMode {
         INSERT,
+        MULTI,
         UPSERT,
         UPDATE;
     }
@@ -105,6 +106,8 @@ public class JdbcSinkConfig extends JdbcConfig {
         "The insertion mode to use. Supported modes are:\n"
             + "``insert``\n"
             + "    Use standard SQL ``INSERT`` statements.\n"
+            + "``multi``\n"
+            + "    Use multi-row ``INSERT`` statements.\n"
             + "``upsert``\n"
             + "    Use the appropriate upsert semantics for the target database if it is supported by "
             + "the connector, e.g. ``INSERT .. ON CONFLICT .. DO UPDATE SET ..``.\n"

--- a/src/main/java/io/aiven/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/PreparedStatementBinder.java
@@ -68,6 +68,7 @@ public class PreparedStatementBinder implements StatementBinder {
         int index = 1;
         switch (insertMode) {
             case INSERT:
+            case MULTI:
             case UPSERT:
                 index = bindKeyFields(record, index);
                 bindNonKeyFields(record, valueStruct, index);

--- a/src/main/resources/META-INF/services/io.aiven.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.aiven.connect.jdbc.dialect.DatabaseDialectProvider
@@ -4,6 +4,7 @@ io.aiven.connect.jdbc.dialect.DerbyDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.OracleDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.SqliteDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.PostgreSqlDatabaseDialect$Provider
+io.aiven.connect.jdbc.dialect.RedshiftDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.MySqlDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.aiven.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider


### PR DESCRIPTION
This PR/Spike introduces a new Redshift Dialect and support for multi-row inserts.

Ideally we can roll in Redshift specific optimizations into the dialect. In particular the default data mapping of Kafka Records string to Postgres TEXT results in fields being defined as VARCHAR(256) within Redshift. You can read about the Redshift data type mapping here:
https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html#r_Character_types-storage-and-ranges

For the sake of testing I have arbitrarily mapped string to VARCHAR(5000) but ideally a more deliberate/intelligent mapping would be implemented.

The multi-row insert is aimed at improving performance of a Sink connector writing to Redshift. During testing multi-row inserts are magnitudes faster than the existing single inserts that the insert mode uses. You can read about AWS's recommendation of multi-row insert here:
https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-multi-row-inserts.html