### PR TITLE
Use a transaction-independent timestamp for Postgres: fix #54

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -257,4 +257,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return builder.toString();
     }
 
+    @Override
+    protected String currentTimestampDatabaseQuery() {
+        return "SELECT CLOCK_TIMESTAMP()";
+    }
+
 }


### PR DESCRIPTION
In Postgres, `CURRENT_TIMESTAMP` (and others) change behavior within a
transaction:

> These SQL-standard functions all return values based on the start time
> of the current transaction

(see [1])

In 29581b310781ccc52fa0eec3a00e47da91bac767, the JDBC connection for the
source connector had auto-commit disabled, apparently to force cursor
behavior in some JDBC drivers.  When auto-commit is disabled, a
transaction is opened and not committed until `commit` is called -- and
it's only called in the _sink_ connector.

Because the generic dialect uses `CURRENT_TIMESTAMP` as its timestamp
query, and the Postgres dialect has no override, the end timestamp used
in timestamp- and timestamp+incrementing-mode is calculated using the
timestamp of the transaction start.  The transaction was started when
the connector started up, so this timestamp always reads the same.

In effect, the connector must be continually restarted for
timestamp-based querying to function in Postgres.

See #54 for example logs illustrating this.

There are a couple of possible ways to work around this:

- turn auto-commit back on just for postgres (not sure the ideal place
  to do this, or if it's too big of a change)
- explicitly commit after each statement
- make the postgres time query return the actual "current time"

In this PR, I have opted for the third option.  The `CLOCK_TIMESTAMP()`
function is the equivalent of `CURRENT_TIMESTAMP`, returning a
`timestamp with time zone` without taking transactions into account:

> Current date and time (changes during statement execution)

(see [1])

With this change, timestamp querying should function as expected.

[1]: https://www.postgresql.org/docs/12/functions-datetime.html