### PR TITLE
Add Github Actions workflows

### DIFF
--- a/.github/workflows/master_push_workflow.yml
+++ b/.github/workflows/master_push_workflow.yml
@@ -1,0 +1,20 @@
+# The workflow to check master after push.
+name: Master checks after push
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -1,0 +1,19 @@
+# The workflow to check pull requests into master.
+# This checks the source in the state as if after the merge.
+name: Pull request checks
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/release_pr_workflow.yml
+++ b/.github/workflows/release_pr_workflow.yml
@@ -1,0 +1,58 @@
+# The workflow to create PRs with release commits.
+name: Create release PR
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version '0.1.2' (without 'v')"
+        required: true
+      snapshot_version:
+        description: "Snapshot version '0.2.0-SNAPSHOT' (without 'v')"
+        required: true
+
+jobs:
+  create_release_pr:
+    name: Create release PR (job)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check versions
+        run: |
+          echo "Checking release version..."
+          if echo ${{ github.event.inputs.release_version }} | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+$' > /dev/null; then
+            echo "Release version is invalid"
+            exit 1
+          fi
+
+          echo "Checking snapshot version..."
+          if echo ${{ github.event.inputs.snapshot_version }} | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT$' > /dev/null; then
+            echo "Snapshot version is invalid"
+            exit 1
+          fi
+
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Create release commits
+        run: |
+          git config --local user.name "GitHub Action"
+          git config --local user.email "action@github.com"
+          sed -i -e "s/^version=.\+$/version=${{ github.event.inputs.release_version }}/g" gradle.properties
+          git add gradle.properties
+          git commit -m "Release version ${{ github.event.inputs.release_version }}"
+          sed -i -e "s/^version=.\+$/version=${{ github.event.inputs.snapshot_version }}/g" gradle.properties
+          git add gradle.properties
+          git commit -m "Bump version to ${{ github.event.inputs.snapshot_version }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: release-${{ github.event.inputs.release_version }}
+          delete-branch: true
+          draft: true
+          title: Release version ${{ github.event.inputs.release_version }}
+          body: |
+            Proposed changelog:
+              - *fill in*


### PR DESCRIPTION
This adds three workflows:
- `pull_request_workflow.yml` that checks the build on a pull request;
- `master_push_workflow.yml` that checks the build on a push into `master` (including merges);
- `release_pr_workflow.yml` that creates a release PR.

It's effectively a copy from https://github.com/aiven/aiven-kafka-connect-commons/tree/master/.github/workflows