### PR TITLE
Setup jdk version in workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,11 +12,16 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Java SDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.commit_hash }}
-
+      
       - name: Check commit title and extract version
         run: |
           export commit_title=$(git log --pretty=format:%s -1 ${{ github.event.inputs.commit_hash }})


### PR DESCRIPTION
The default JDK version in workflow build is 8 while we use 11.
This change set up JDK version to 11 for the build