### PR TITLE
Fix release workflow to use correct commit

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.commit_hash }}
-      
+
       - name: Check commit title and extract version
         run: |
           export commit_title=$(git log --pretty=format:%s -1 ${{ github.event.inputs.commit_hash }})
@@ -56,6 +56,7 @@ jobs:
         with:
           tag_name: "v${{ env.version }}"
           release_name: "v${{ env.version }}"
+          commitish: ${{ github.event.inputs.commit_hash }}
           body: |
             *Fill in*
           draft: true


### PR DESCRIPTION
By default (omitting commitish) actions/create-release uses repository's default branch ie. last commit in master branch.  Fix this by explicitly defining commit to use in release.