### PR TITLE
Delete no longer used TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Kafka Connect JDBC Connector
 
-[![Build Status](https://travis-ci.org/aiven/aiven-kafka-connect-jdbc.svg?branch=master)](https://travis-ci.org/aiven/aiven-kafka-connect-jdbc)
-
 This repository includes a Sink and Source
 [Kafka Connect](http://kafka.apache.org/documentation.html#connect)
 connectors for JDBC-compatible databases.


### PR DESCRIPTION
TravisCI was replaced with GitHub Actions in #71 but README badge was not catched at that time.