### PR TITLE
Remove cruft version.txt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ distributions {
 
             into("/") {
                 from projectDir
-                include "version.txt", "README*", "LICENSE*", "NOTICE*", "licenses/"
+                include "README*", "LICENSE*", "NOTICE*", "licenses/"
                 include "config/"
             }
         }

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,0 @@
-##This file must be updated at package time to have a valid package##
-invalid


### PR DESCRIPTION
Remove unused version.txt which contained `invalid` even in release packages.  Version number is handled nowadays in `gradle.properties` file.