### PR TITLE
fixed currentTimestampDatabase query for some db2 driver/database pairs

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/dialect/Db2DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/Db2DatabaseDialect.java
@@ -62,7 +62,7 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
 
     @Override
     protected String currentTimestampDatabaseQuery() {
-        return "SELECT CURRENT_TIMESTAMP(12) FROM SYSIBM.SYSDUMMY1;";
+        return "SELECT CURRENT_TIMESTAMP(12) FROM SYSIBM.SYSDUMMY1";
     }
 
     @Override


### PR DESCRIPTION
semicolon caused problems

`
2021-08-12 11:50:24,678 ERROR Failed to get current time from DB using Db2 and query 'SELECT CURRENT_TIMESTAMP(12) FROM SYSIBM.SYSDUMMY1;' (io.aiven.connect.jdbc.dialect.Db2DatabaseDialect) [task-thread-kafka-db2-source-connector-0]
com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-104, SQLSTATE=42601, SQLERRMC=;;ROM SYSIBM.SYSDUMMY1;END-OF-STATEMENT, DRIVER=4.29.24
	at com.ibm.db2.jcc.am.b7.a(b7.java:810)
	at com.ibm.db2.jcc.am.b7.a(b7.java:66)
	at com.ibm.db2.jcc.am.b7.a(b7.java:140)
	at com.ibm.db2.jcc.am.k9.c(k9.java:2844)
	at com.ibm.db2.jcc.am.k9.d(k9.java:2828)
	at com.ibm.db2.jcc.am.k9.a(k9.java:2254)
	at com.ibm.db2.jcc.t4.ab.i(ab.java:204)
	at com.ibm.db2.jcc.t4.ab.b(ab.java:94)
	at com.ibm.db2.jcc.t4.p.a(p.java:32)
	at com.ibm.db2.jcc.t4.av.i(av.java:150)
	at com.ibm.db2.jcc.am.k9.al(k9.java:2223)
	at com.ibm.db2.jcc.am.k9.a(k9.java:3351)
	at com.ibm.db2.jcc.am.k9.a(k9.java:741)
	at com.ibm.db2.jcc.am.k9.executeQuery(k9.java:720)
	at io.aiven.connect.jdbc.dialect.GenericDatabaseDialect.currentTimeOnDB(GenericDatabaseDialect.java:465)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.endTimestampValue(TimestampIncrementingTableQuerier.java:220)
	at io.aiven.connect.jdbc.source.TimestampIncrementingCriteria.setQueryParametersTimestamp(TimestampIncrementingCriteria.java:167)
	at io.aiven.connect.jdbc.source.TimestampIncrementingCriteria.setQueryParameters(TimestampIncrementingCriteria.java:129)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.executeQuery(TimestampIncrementingTableQuerier.java:188)
	at io.aiven.connect.jdbc.source.TableQuerier.maybeStartQuery(TableQuerier.java:97)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.maybeStartQuery(TimestampIncrementingTableQuerier.java:62)
	at io.aiven.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:321)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.poll(WorkerSourceTask.java:289)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:256)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:185)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
2021-08-12 11:50:24,688 ERROR Failed to run query for table TimestampIncrementingTableQuerier{table="USR01069"."FE_DBACTION", query='null', topicPrefix='test-topic', incrementingColumn='', timestampColumns=[CREATEDAT]}: {} (io.aiven.connect.jdbc.source.JdbcSourceTask) [task-thread-kafka-db2-source-connector-0]
com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-104, SQLSTATE=42601, SQLERRMC=;;ROM SYSIBM.SYSDUMMY1;END-OF-STATEMENT, DRIVER=4.29.24
	at com.ibm.db2.jcc.am.b7.a(b7.java:810)
	at com.ibm.db2.jcc.am.b7.a(b7.java:66)
	at com.ibm.db2.jcc.am.b7.a(b7.java:140)
	at com.ibm.db2.jcc.am.k9.c(k9.java:2844)
	at com.ibm.db2.jcc.am.k9.d(k9.java:2828)
	at com.ibm.db2.jcc.am.k9.a(k9.java:2254)
	at com.ibm.db2.jcc.t4.ab.i(ab.java:204)
	at com.ibm.db2.jcc.t4.ab.b(ab.java:94)
	at com.ibm.db2.jcc.t4.p.a(p.java:32)
	at com.ibm.db2.jcc.t4.av.i(av.java:150)
	at com.ibm.db2.jcc.am.k9.al(k9.java:2223)
	at com.ibm.db2.jcc.am.k9.a(k9.java:3351)
	at com.ibm.db2.jcc.am.k9.a(k9.java:741)
	at com.ibm.db2.jcc.am.k9.executeQuery(k9.java:720)
	at io.aiven.connect.jdbc.dialect.GenericDatabaseDialect.currentTimeOnDB(GenericDatabaseDialect.java:465)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.endTimestampValue(TimestampIncrementingTableQuerier.java:220)
	at io.aiven.connect.jdbc.source.TimestampIncrementingCriteria.setQueryParametersTimestamp(TimestampIncrementingCriteria.java:167)
	at io.aiven.connect.jdbc.source.TimestampIncrementingCriteria.setQueryParameters(TimestampIncrementingCriteria.java:129)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.executeQuery(TimestampIncrementingTableQuerier.java:188)
	at io.aiven.connect.jdbc.source.TableQuerier.maybeStartQuery(TableQuerier.java:97)
	at io.aiven.connect.jdbc.source.TimestampIncrementingTableQuerier.maybeStartQuery(TimestampIncrementingTableQuerier.java:62)
	at io.aiven.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:321)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.poll(WorkerSourceTask.java:289)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:256)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:185)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
`