### PR TITLE
fix(postgres): support column casting for multi-row inserts

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
@@ -328,6 +328,7 @@ public interface DatabaseDialect extends ConnectionProvider {
      * Build an INSERT statement for multiple rows.
      *
      * @param table            the identifier of the table; may not be null
+     * @param tableDefinition  the table definition; may be null if unknown
      * @param records          number of rows which will be inserted; must be a positive number
      * @param keyColumns       the identifiers of the columns in the primary/unique key; may not be null
      *                         but may be empty
@@ -337,6 +338,7 @@ public interface DatabaseDialect extends ConnectionProvider {
      */
     String buildMultiInsertStatement(
         TableId table,
+        TableDefinition tableDefinition,
         int records,
         Collection<ColumnId> keyColumns,
         Collection<ColumnId> nonKeyColumns

--- a/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1367,6 +1367,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
     @Override
     public String buildMultiInsertStatement(final TableId table,
+                                            final TableDefinition tableDefinition,
                                             final int records,
                                             final Collection<ColumnId> keyColumns,
                                             final Collection<ColumnId> nonKeyColumns) {

--- a/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -49,6 +49,10 @@ import io.aiven.connect.jdbc.util.IdentifierRules;
 import io.aiven.connect.jdbc.util.TableDefinition;
 import io.aiven.connect.jdbc.util.TableId;
 
+import static io.aiven.connect.jdbc.util.CollectionUtils.isEmpty;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.IntStream.range;
+
 /**
  * A {@link DatabaseDialect} for PostgreSQL.
  */
@@ -323,6 +327,48 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
                 .of(keyColumns, nonKeyColumns)
                 .append(")")
                 .toString();
+    }
+
+    @Override
+    public String buildMultiInsertStatement(final TableId table,
+                                            final TableDefinition tableDefinition,
+                                            final int records,
+                                            final Collection<ColumnId> keyColumns,
+                                            final Collection<ColumnId> nonKeyColumns) {
+
+        if (records < 1) {
+            throw new IllegalArgumentException("number of records must be a positive number, but got: " + records);
+        }
+        if (isEmpty(keyColumns) && isEmpty(nonKeyColumns)) {
+            throw new IllegalArgumentException("no columns specified");
+        }
+        requireNonNull(table, "table must not be null");
+
+        final String insertStatement = expressionBuilder()
+                .append("INSERT INTO ")
+                .append(table)
+                .append("(")
+                .appendList()
+                .delimitedBy(",")
+                .transformedBy(ExpressionBuilder.columnNames())
+                .of(keyColumns, nonKeyColumns)
+                .append(") VALUES")
+                .toString();
+
+        final String singleRowPlaceholder = expressionBuilder()
+                .append("(")
+                .appendList()
+                .delimitedBy(",")
+                .transformedBy(transformColumn(tableDefinition))
+                .of(keyColumns, nonKeyColumns)
+                .append(")")
+                .toString();
+
+        final String allRowsPlaceholder = range(1, records + 1)
+                .mapToObj(i -> singleRowPlaceholder)
+                .collect(Collectors.joining(","));
+
+        return insertStatement + allRowsPlaceholder;
     }
 
     @Override

--- a/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
@@ -319,6 +319,7 @@ public class BufferedRecords {
         try {
             return dbDialect.buildMultiInsertStatement(
                     tableId,
+                    tableDefinition,
                     records.size(),
                     asColumns(fieldsMetadata.keyFieldNames),
                     asColumns(fieldsMetadata.nonKeyFieldNames)

--- a/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -226,6 +226,42 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     }
 
     @Test
+    public void shouldBuildMultiInsertStatementMultipleRecords() {
+        final String expected = readQueryResourceForThisTest("multi_2_insert0");
+        final String actual = dialect.buildMultiInsertStatement(
+                castTypesTableId,
+                castTypesTableDefinition,
+                2,
+                List.of(castTypesPkColumn),
+                List.of(columnUuid, columnJson, columnJsonb));
+        assertQueryEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldBuildMultiInsertStatementSingleRecord() {
+        final String expected = readQueryResourceForThisTest("multi_1_insert0");
+        final String actual = dialect.buildMultiInsertStatement(
+                castTypesTableId,
+                castTypesTableDefinition,
+                1,
+                List.of(castTypesPkColumn),
+                List.of(columnUuid, columnJson, columnJsonb));
+        assertQueryEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldBuildMultiInsertStatementZeroRecords() {
+        assertThatThrownBy(() -> dialect.buildMultiInsertStatement(
+                castTypesTableId,
+                castTypesTableDefinition,
+                0,
+                List.of(castTypesPkColumn),
+                List.of(columnUuid, columnJson, columnJsonb)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("number of records must be a positive number, but got: 0");
+    }
+
+    @Test
     public void shouldBuildUpdateStatement() {
         final String expected = readQueryResourceForThisTest("update0");
         final String actual = dialect.buildUpdateStatement(

--- a/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_1_insert0-nonquoted.txt
+++ b/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_1_insert0-nonquoted.txt
@@ -1,0 +1,1 @@
+INSERT INTO cast_types_table(pk,uuid_col,json_col,jsonb_col) VALUES(?,?::uuid,?::json,?::jsonb)

--- a/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_1_insert0-quoted.txt
+++ b/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_1_insert0-quoted.txt
@@ -1,0 +1,1 @@
+INSERT INTO "cast_types_table"("pk","uuid_col","json_col","jsonb_col") VALUES(?,?::uuid,?::json,?::jsonb)

--- a/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_2_insert0-nonquoted.txt
+++ b/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_2_insert0-nonquoted.txt
@@ -1,0 +1,1 @@
+INSERT INTO cast_types_table(pk,uuid_col,json_col,jsonb_col) VALUES(?,?::uuid,?::json,?::jsonb),(?,?::uuid,?::json,?::jsonb)

--- a/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_2_insert0-quoted.txt
+++ b/src/test/resources/io.aiven.connect.jdbc.dialect/PostgreSqlDatabaseDialectTest/multi_2_insert0-quoted.txt
@@ -1,0 +1,1 @@
+INSERT INTO "cast_types_table"("pk","uuid_col","json_col","jsonb_col") VALUES(?,?::uuid,?::json,?::jsonb),(?,?::uuid,?::json,?::jsonb)


### PR DESCRIPTION
Previously, when configuring the sink connector with `insert.mode=multi` for a PostgreSQL database, the parent class `GenericDatabaseDialect` was responsible for generating the multi-row insert SQL. This "bypassed" the PostgreSQL dialect's specific casting logic (e.g., casting a string to `jsonb` if the column has that type).

This patch overrides `buildMultiInsertStatement` within the PostgreSQL dialect. This ensures multi-row inserts now behave consistently with single-row inserts, properly applying all required column casts (by calling `transformColumn`).