### PR TITLE
fix: escape quote characters in SQL identifiers to prevent SQL injection

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/util/ExpressionBuilder.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/ExpressionBuilder.java
@@ -309,10 +309,13 @@ public class ExpressionBuilder {
     ) {
         if (quoted) {
             appendLeadingQuote();
-        }
-        sb.append(name);
-        if (quoted) {
+            sb.append(name.replace(
+                rules.trailingQuoteString(),
+                rules.trailingQuoteString() + rules.trailingQuoteString()
+            ));
             appendTrailingQuote();
+        } else {
+            sb.append(name);
         }
         return this;
     }
@@ -328,10 +331,13 @@ public class ExpressionBuilder {
     public ExpressionBuilder appendIdentifier(final String name) {
         if (quoteIdentifiers) {
             appendLeadingQuote();
-        }
-        sb.append(name);
-        if (quoteIdentifiers) {
+            sb.append(name.replace(
+                rules.trailingQuoteString(),
+                rules.trailingQuoteString() + rules.trailingQuoteString()
+            ));
             appendTrailingQuote();
+        } else {
+            sb.append(name);
         }
         return this;
     }

--- a/src/test/java/io/aiven/connect/jdbc/util/ExpressionBuilderTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/util/ExpressionBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.jdbc.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpressionBuilderTest {
+
+    @Test
+    public void testAppendIdentifierWithEmbeddedQuote() {
+        // A field name containing a double-quote should be escaped by doubling
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.appendIdentifier("col\" OR 1=1 --");
+        // The embedded " must be escaped to "" per SQL standard
+        assertThat(builder.toString()).isEqualTo("\"col\"\" OR 1=1 --\"");
+    }
+
+    @Test
+    public void testAppendIdentifierWithEmbeddedQuoteAndBoolean() {
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.appendIdentifier("col\" OR 1=1 --", true);
+        assertThat(builder.toString()).isEqualTo("\"col\"\" OR 1=1 --\"");
+    }
+
+    @Test
+    public void testAppendIdentifierWithoutQuote() {
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.appendIdentifier("normal_col", false);
+        assertThat(builder.toString()).isEqualTo("normal_col");
+    }
+
+    @Test
+    public void testAppendIdentifierNoEmbeddedQuote() {
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.appendIdentifier("safe_column");
+        assertThat(builder.toString()).isEqualTo("\"safe_column\"");
+    }
+
+    @Test
+    public void testAppendIdentifierWithMySQLBacktick() {
+        final IdentifierRules mysqlRules = new IdentifierRules("`");
+        final ExpressionBuilder builder = new ExpressionBuilder(mysqlRules, true);
+        builder.appendIdentifier("col` OR 1=1 --");
+        assertThat(builder.toString()).isEqualTo("`col`` OR 1=1 --`");
+    }
+
+    @Test
+    public void testAppendIdentifierSQLInjectionDELETE() {
+        // Simulates the DELETE WHERE clause injection scenario
+        // Field name: id" OR 1=1 --
+        // Without fix: DELETE FROM "t" WHERE "id" OR 1=1 --" = ?
+        // With fix:    DELETE FROM "t" WHERE "id"" OR 1=1 --" = ?
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.append("DELETE FROM \"t\" WHERE ");
+        builder.appendIdentifier("id\" OR 1=1 --");
+        builder.append(" = ?");
+        assertThat(builder.toString()).isEqualTo("DELETE FROM \"t\" WHERE \"id\"\" OR 1=1 --\" = ?");
+    }
+
+    @Test
+    public void testAppendIdentifierSQLInjectionINSERT() {
+        // Simulates the INSERT column list injection scenario
+        final ExpressionBuilder builder = ExpressionBuilder.create();
+        builder.append("INSERT INTO \"t\" (");
+        builder.appendIdentifier("name\", \"email\"); DROP TABLE users; --");
+        builder.append(") VALUES (?)");
+        assertThat(builder.toString()).isEqualTo(
+            "INSERT INTO \"t\" (\"name\"\", \"email\"\"); DROP TABLE users; --\") VALUES (?)");
+    }
+}


### PR DESCRIPTION
## Summary

`ExpressionBuilder.appendIdentifier()` wraps SQL identifiers with quote characters but never escapes the quote character embedded within the identifier itself. This enables SQL injection through crafted Kafka message schema field names.

## Vulnerability

A field name like `col" OR 1=1 --` produces:


"col" OR 1=1 --"


The embedded `"` breaks out of the quoting, turning the identifier into executable SQL code. This affects INSERT, DELETE, and CREATE TABLE statements generated by the connector.

### Attack vector

Kafka message schema field names flow unescaped into SQL identifiers via `FieldsMetadata.extract()` → `GenericDatabaseDialect.buildInsertStatement()` / `buildDeleteStatement()` / `buildCreateTableStatement()` → `ExpressionBuilder.appendIdentifier()`.

An attacker who can produce Kafka messages with arbitrary schema field names (e.g., via JSON converter) can inject arbitrary SQL into statements executed against the target database.

### Exploit example (DELETE injection with `delete.enabled=true`)

Field name: `id" OR 1=1 --`

Before fix:

DELETE FROM "table" WHERE "id" OR 1=1 --" = ?


The `--` comments out `" = ?`, making the WHERE clause a tautology. All rows are deleted.

After fix:

DELETE FROM "table" WHERE "id"" OR 1=1 --" = ?


The `""` is a literal quote character inside the identifier. The WHERE clause correctly references column `id" OR 1=1 --`.

## Fix

Escape embedded trailing quote characters by doubling them (SQL standard), in both `appendIdentifier()` overloads.

## Tests

Added `ExpressionBuilderTest` covering:
- Embedded double-quote in default-quoted identifiers
- Embedded backtick in MySQL-quoted identifiers
- DELETE WHERE clause injection scenario
- INSERT column list injection scenario

## References

- CWE-89: SQL Injection