### PR TITLE
Fix PostgreSQL boolean default values

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -58,6 +58,28 @@ import static java.util.stream.IntStream.range;
  */
 public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
+    @Override
+    protected void formatColumnValue(
+            final ExpressionBuilder builder,
+            final String schemaName,
+            final Map<String, String> schemaParameters,
+            final Schema.Type type,
+            final Object value
+    ) {
+        if (type == Schema.Type.BOOLEAN) {
+            builder.append((Boolean) value ? "TRUE" : "FALSE");
+            return;
+        }
+
+        super.formatColumnValue(
+                builder,
+                schemaName,
+                schemaParameters,
+                type,
+                value
+        );
+    }
+
     private static final Map<Schema.Type, Class<?>> SUPPORTED_ARRAY_VALUE_TYPES_TO_JAVA = Map.of(
             Schema.Type.INT8, short.class,
             Schema.Type.INT16, short.class,

--- a/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -469,5 +470,25 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             () -> dialect.bindField(mock(PreparedStatement.class), 1, bytesSchema, Collections.emptyMap()))
                 .isInstanceOf(DataException.class)
                 .hasMessage("Unsupported schema type BYTES for ARRAY values");
+    }
+
+    @Test
+    public void shouldUseTrueLiteralForBooleanTrueDefault() {
+        final Schema booleanSchema = SchemaBuilder.bool()
+                .defaultValue(true)
+                .build();
+
+        final SinkRecordField booleanField = new SinkRecordField(
+                booleanSchema,
+                "is_active",
+                false
+        );
+
+        final String actual = dialect.buildCreateTableStatement(
+                tableId,
+                Collections.singletonList(booleanField)
+        );
+
+        assertThat(actual).contains("BOOLEAN DEFAULT TRUE");
     }
 }

--- a/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -37,6 +36,7 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.aiven.connect.jdbc.sink.metadata.SinkRecordField;
 import io.aiven.connect.jdbc.source.ColumnMapping;
 import io.aiven.connect.jdbc.util.ColumnDefinition;
 import io.aiven.connect.jdbc.util.ColumnId;


### PR DESCRIPTION
Fixes #173

PostgreSQL does not accept integer literals (`1`/`0`) as default values for `BOOLEAN` columns.

This change updates the PostgreSQL dialect to format boolean default values as `TRUE`/`FALSE` instead.

### Testing

- Reproduced the issue locally with Kafka Connect and PostgreSQL.
- Added a regression test for PostgreSQL boolean default values.
- `PostgreSqlDatabaseDialectTest` passes.