### PR TITLE
Update integration tests for AssertJ DB 3.x API

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -48,6 +48,8 @@
 
     <suppress checks="ClassFanOutComplexity"
               files="(DatabaseDialect|GenericDatabaseDialect).java"/>
+    <suppress checks="ClassFanOutComplexity"
+              files="AbstractIT.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling" files=".*Test|ConnectRunner.java"/>
     <suppress checks="JavaNCSS" files=".*Test\.java"/>

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
@@ -16,9 +16,12 @@
 
 package io.aiven.kafka.connect.jdbc;
 
+import javax.sql.DataSource;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +37,9 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import org.apache.avro.generic.GenericRecord;
+import org.assertj.db.type.AssertDbConnection;
+import org.assertj.db.type.AssertDbConnectionFactory;
+import org.assertj.db.type.Table;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -69,6 +75,8 @@ public abstract class AbstractIT {
 
     protected ConnectRunner connectRunner;
 
+    protected AssertDbConnection connection;
+
     @BeforeEach
     void startKafka() throws Exception {
         LOGGER.info("Configure Kafka connect plugins");
@@ -77,6 +85,14 @@ public abstract class AbstractIT {
         setupKafkaConnect(pluginDir);
         producer = createProducer();
         consumer = createConsumer();
+        // Initialize AssertJ DB connection for database assertions
+        connection = AssertDbConnectionFactory.of(getDatasource()).create();
+    }
+
+    protected abstract DataSource getDatasource() throws SQLException;
+
+    protected Table table(final String tableName) {
+        return connection.table(tableName).build();
     }
 
     private static Path setupPluginDir() throws Exception {

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyDeleteIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyDeleteIT.java
@@ -31,7 +31,6 @@ import io.aiven.connect.jdbc.JdbcSinkConnector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.assertj.db.type.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -157,8 +156,8 @@ public class VerifyDeleteIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2");
@@ -169,8 +168,8 @@ public class VerifyDeleteIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(2);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(2);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2");
                 });
@@ -188,7 +187,7 @@ public class VerifyDeleteIT extends AbstractOracleIT {
         // TODO: Instead of sleeping for a fixed interval,
         //  wait for the connector to commit offsets for the records we sent
         Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
-        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+        assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(0);
     }
 
     @Test
@@ -203,8 +202,8 @@ public class VerifyDeleteIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")
@@ -216,8 +215,8 @@ public class VerifyDeleteIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(4);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(4);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")
                             .value().isEqualTo("3")
@@ -238,7 +237,7 @@ public class VerifyDeleteIT extends AbstractOracleIT {
         // TODO: Instead of sleeping for a fixed interval,
         //  wait for the connector to commit offsets for the records we sent
         Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
-        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+        assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(0);
     }
 
     @Test
@@ -253,8 +252,8 @@ public class VerifyDeleteIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("2")
                             .value().isEqualTo("3")
                             .value().isEqualTo("4");

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyInsertIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyInsertIT.java
@@ -31,7 +31,6 @@ import io.aiven.connect.jdbc.JdbcSinkConnector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.assertj.db.type.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -144,8 +143,8 @@ public class VerifyInsertIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -163,8 +162,8 @@ public class VerifyInsertIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -182,8 +181,8 @@ public class VerifyInsertIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -201,8 +200,8 @@ public class VerifyInsertIT extends AbstractOracleIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
@@ -31,7 +31,6 @@ import io.aiven.connect.jdbc.JdbcSinkConnector;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.assertj.db.type.Table;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.avro.generic.GenericData.Record;
@@ -77,7 +76,7 @@ public class PartitionedTableIntegrationTest extends AbstractPostgresIT {
         sendTestData(1000);
 
         await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(100))
-            .untilAsserted(() -> assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1000));
+            .untilAsserted(() -> assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1000));
     }
 
     @Test
@@ -89,7 +88,7 @@ public class PartitionedTableIntegrationTest extends AbstractPostgresIT {
         sendTestData(1000);
 
         await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(100))
-            .untilAsserted(() -> assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1000));
+            .untilAsserted(() -> assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1000));
     }
 
     private void sendTestData(final int numberOfRecords) throws InterruptedException, ExecutionException {

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyDeleteIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyDeleteIT.java
@@ -31,7 +31,6 @@ import io.aiven.connect.jdbc.JdbcSinkConnector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.assertj.db.type.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -157,8 +156,8 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2");
@@ -169,8 +168,8 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(2);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(2);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2");
                 });
@@ -188,7 +187,7 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
         // TODO: Instead of sleeping for a fixed interval,
         //  wait for the connector to commit offsets for the records we sent
         Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
-        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+        assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(0);
     }
 
     @Test
@@ -203,8 +202,8 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")
@@ -216,8 +215,8 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(4);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(4);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")
                             .value().isEqualTo("3")
@@ -238,7 +237,7 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
         // TODO: Instead of sleeping for a fixed interval,
         //  wait for the connector to commit offsets for the records we sent
         Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
-        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+        assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(0);
     }
 
     @Test
@@ -253,8 +252,8 @@ public class VerifyDeleteIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("2")
                             .value().isEqualTo("3")
                             .value().isEqualTo("4");

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyInsertIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyInsertIT.java
@@ -31,7 +31,6 @@ import io.aiven.connect.jdbc.JdbcSinkConnector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.assertj.db.type.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -143,8 +142,8 @@ public class VerifyInsertIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -162,8 +161,8 @@ public class VerifyInsertIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -181,8 +180,8 @@ public class VerifyInsertIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0");
                 });
     }
@@ -200,8 +199,8 @@ public class VerifyInsertIT extends AbstractPostgresIT {
 
         await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> {
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
-                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                    assertThat(table(TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(table(TEST_TOPIC_NAME)).column("ID")
                             .value().isEqualTo("0")
                             .value().isEqualTo("1")
                             .value().isEqualTo("2")

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -309,7 +309,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
         db.insert(SINGLE_TABLE_NAME, "modified", new Timestamp(currentTime + 501L).toString(), "id", 5);
 
         // avoid flaky test where only 1 record gets received
-        Thread.sleep(1);
+        Thread.sleep(10);
         verifyPoll(2, "id", Arrays.asList(2, 3), true, false, false, TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
         // make sure we get the rest


### PR DESCRIPTION
## Summary

Updates the integration tests for compatibility with AssertJ DB 3.x, where the previous `Table(DataSource, String)` constructor is no longer available.

- Replace the old `Table(DataSource, String)` usage with `AssertDbConnection` and the table builder API.
- Centralize the AssertJ DB connection setup for integration tests.

The second commit separately stabilizes `testTimestampWithDelay`, which was timing-sensitive when running the full test suite and could return only one record instead of the expected two.

## Testing

- `./gradlew compileIntegrationTestJava`
- `./gradlew integrationTest`
- `./gradlew test --rerun-tasks`